### PR TITLE
bug/fix Emote events when injected into ffz

### DIFF
--- a/src/Sites/twitch.tv/FFZ/FrankerFaceZ.Addon.ts
+++ b/src/Sites/twitch.tv/FFZ/FrankerFaceZ.Addon.ts
@@ -47,7 +47,7 @@ class SevenTVEmotes extends FrankerFaceZ.utilities.addon.Addon {
 		this.enable();
 
 		// Handle WzbSocket Messages
-		window.addEventListener('7TV#ChannelEmoteChange', (event) => {
+		window.addEventListener('7TV#ChannelEmoteUpdate', (event) => {
 			const data = JSON.parse(((event as CustomEvent).detail));
 			this.handleChannelEmoteUpdate(data);
 		});


### PR DESCRIPTION
This fixes the automatic emote update when updating a 7tv emote using the ffz addon.
