### PR TITLE
Hide User-Specific FFZ Emotes

### DIFF
--- a/src/Global/API.ts
+++ b/src/Global/API.ts
@@ -204,6 +204,7 @@ export namespace API {
 	export type EmoteProviderList = [EmoteProvider?, EmoteProvider?];
 	export namespace FFZ {
 		export interface RoomResponse {
+			default_sets: string[],
 			sets: {
 				[key: string]: {
 					emoticons: FFZ.Emote[];

--- a/src/Global/API.ts
+++ b/src/Global/API.ts
@@ -82,7 +82,7 @@ export class API {
 
 	GetFrankerFaceZGlobalEmotes(): Observable<DataStructure.Emote[]> {
 		return this.createRequest<API.FFZ.RoomResponse>(`/set/global`, { method: 'GET', baseUrl: this.BASE_URL_FFZ }).pipe(
-			map(res => Object.keys(res?.body.sets).map(k => res?.body.sets[k].emoticons).reduce((a, b) => [...a, ...b])),
+			map(res => Object.values(res?.body.default_sets).map(k => res?.body.sets[k].emoticons).reduce((a, b) => [...a, ...b])),
 			mergeAll(),
 			map(emote => this.transformFFZ(emote, true)),
 			toArray()


### PR DESCRIPTION
Partially resolves #212

If you don't want to support user-specific global emotes, this is the bare minimum to hide them from the list entirely.