### PR TITLE
Update gitmodules to support both https and ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Typings"]
 	path = Typings
-	url = git@github.com:SevenTV/Typings.git
+	url = ../Typings.git


### PR DESCRIPTION
Allows for cloning the repository with both https and ssh. 
The current config causes errors if the user has not set up ssh keys.