### PR TITLE
Adjust 7tv Emote Menu styles.

### DIFF
--- a/src/Style/Components/EmoteMenu.scss
+++ b/src/Style/Components/EmoteMenu.scss
@@ -1,81 +1,109 @@
-.seventv-emote-menu {	
-	position: absolute;
+.seventv-emote-menu {
+  position: absolute;
+  scroll-behavior: smooth;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  width: 30rem;
 
-	.seventv-emote-menu-header {
-		background-color: var(--seventv-color-background-1);
-		display: flex;
-		flex-direction: row;
-		justify-content: space-between;
-		border-radius: 0.4rem;
-	}
-	.seventv-emote-menu-scrollable {
-		background-color: var(--seventv-color-background-0);
-		padding-top: 1em;
-		border-radius: 0.6rem;
-		width: 30rem;
-		height: 30rem;
-		overflow: auto;
-	}
-	.seventv-emote-menu-tab {
-		background-color: var(--seventv-color-background-1);
-		display: flex;
-		justify-content: center;
-		flex-grow: 1;
-		min-height: 3em;
+  .seventv-emote-menu-header {
+    background-color: var(--seventv-color-background-1);
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    border-radius: 0.4rem 0.4rem 0 0;
+    overflow: hidden;
+  }
+  .seventv-emote-menu-scrollable {
+    background-color: var(--seventv-color-background-0);
+    padding-top: 1em;
+    height: 30rem;
+    overflow: auto;
 
-		&.selected {
-			border-bottom: 0.1rem solid white !important;
-		}
-	}
-	.seventv-emote-menu-emote-list-section {
-		margin-top: 1em;
-		margin-left: 1em;
-	}
-	.seventv-emote-menu-category-header {
-		display: flex;
-		width: 100%;
-		justify-content: center;
-		font-size: 1.65rem;
+    // Scrollbar Styling
+    scrollbar-width: thin;
+    scrollbar-color: var(--seventv-color-background-1) var(--seventv-color-background-0);
+  }
+  .seventv-emote-menu-tab {
+    background-color: var(--seventv-color-background-1);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    flex-grow: 1;
+    cursor: pointer;
+    min-height: 3em;
+    border-style: none;
 
-		border-style: solid;
-		border-bottom-width: 0.1rem;
-		border-color: white;
-	}
-	.seventv-emote-menu-emote-list {
-		display: flex;
-		flex-wrap: wrap;
+    &.selected {
+      border-bottom: 0.1rem solid white !important;
+    }
+  }
+  .seventv-emote-menu-emote-list-section {
+    margin-top: 1em;
+    margin-left: 1em;
+  }
+  .seventv-emote-menu-category-header {
+    display: flex;
+    width: 100%;
+    justify-content: center;
+    font-size: 1.65rem;
 
-		margin-top: 1em;
-		margin-right: .25em;
-		margin-left: 1.25em;
-		margin-bottom: 1em;
+    border-style: solid;
+    border-bottom-width: 0.1rem;
+    border-color: white;
+  }
+  .seventv-emote-menu-emote-list {
+    display: flex;
+    flex-wrap: wrap;
 
-		span {
-			margin-right: .2em;
-			margin-left: .2em;
-			margin-top: .1em;
-			margin-bottom: .1em;
-		}
-	}
-	.seventv-emote-menu-search {
-		background-color: var(--seventv-background-color);
+    margin-top: 1em;
+    margin-right: 0.25em;
+    margin-left: 1.25em;
+    margin-bottom: 1em;
 
-		input {
-			width: 95%;
-			height: 3em;
-			color: white;
-			border-color: white;
-			border-width: 0.1rem;
-			border-style: solid;
-			border-radius: 0.4rem;
-			background-color: var(--seventv-color-background-1);
-			padding: .5em;
-	
-			&:focus {
-				outline: none !important;
-				border: 0.1rem solid rgb(0, 195, 255) ;
-				box-shadow: 0 0 1rem rgb(0, 195, 255) !important;
-			}
-		}
-	}
+    span {
+      margin-right: 0.2em;
+      margin-left: 0.2em;
+      margin-top: 0.1em;
+      margin-bottom: 0.1em;
+    }
+  }
+  .seventv-emote-menu-search {
+    background-color: var(--seventv-background-color);
+    display: flex;
+    flex-direction: row;
+    justify-content: stretch;
+    padding: 0;
+    margin: 0;
+    input {
+      width: 100%;
+      height: 3em;
+      color: white;
+      border-color: white;
+      border-width: 0.1rem;
+      border-style: solid;
+      border-radius: 0 0 0.4rem 0.4rem;
+      background-color: var(--seventv-color-background-1);
+      padding: 0.25em 0.5em;
+      transition: all 0.2s ease-in-out;
+
+      &:focus {
+        outline: none !important;
+        border: 0.1rem solid rgb(0, 195, 255);
+        box-shadow: 0 0 1rem rgb(0, 195, 255) !important;
+      }
+    }
+  }
+
+  & *::-webkit-scrollbar {
+    width: 0.5rem;
+  }
+  & *::-webkit-scrollbar-track {
+    background-color: var(--seventv-color-background-0);
+  }
+  & *::-webkit-scrollbar-thumb {
+    background-color: var(--seventv-color-background-1);
+    border-radius: 0.2rem;
+    border: 0 solid transparent;
+  }
 }

--- a/src/Style/Components/EmoteMenu.scss
+++ b/src/Style/Components/EmoteMenu.scss
@@ -1,109 +1,109 @@
 .seventv-emote-menu {
-  position: absolute;
-  scroll-behavior: smooth;
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  width: 30rem;
+	position: absolute;
+	scroll-behavior: smooth;
+	display: flex;
+	flex-direction: column;
+	align-items: stretch;
+	width: 30rem;
 
-  .seventv-emote-menu-header {
-    background-color: var(--seventv-color-background-1);
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    border-radius: 0.4rem 0.4rem 0 0;
-    overflow: hidden;
-  }
-  .seventv-emote-menu-scrollable {
-    background-color: var(--seventv-color-background-0);
-    padding-top: 1em;
-    height: 30rem;
-    overflow: auto;
+	.seventv-emote-menu-header {
+		background-color: var(--seventv-color-background-1);
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		border-radius: 0.4rem 0.4rem 0 0;
+		overflow: hidden;
+	}
+	.seventv-emote-menu-scrollable {
+		background-color: var(--seventv-color-background-0);
+		padding-top: 1em;
+		height: 30rem;
+		overflow: auto;
 
-    // Scrollbar Styling
-    scrollbar-width: thin;
-    scrollbar-color: var(--seventv-color-background-1) var(--seventv-color-background-0);
-  }
-  .seventv-emote-menu-tab {
-    background-color: var(--seventv-color-background-1);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    flex-grow: 1;
-    cursor: pointer;
-    min-height: 3em;
-    border-style: none;
+		// Scrollbar Styling
+		scrollbar-width: thin;
+		scrollbar-color: var(--seventv-color-background-1) var(--seventv-color-background-0);
+	}
+	.seventv-emote-menu-tab {
+		background-color: var(--seventv-color-background-1);
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		flex-grow: 1;
+		cursor: pointer;
+		min-height: 3em;
+		border-style: none;
 
-    &.selected {
-      border-bottom: 0.1rem solid white !important;
-    }
-  }
-  .seventv-emote-menu-emote-list-section {
-    margin-top: 1em;
-    margin-left: 1em;
-  }
-  .seventv-emote-menu-category-header {
-    display: flex;
-    width: 100%;
-    justify-content: center;
-    font-size: 1.65rem;
+		&.selected {
+			border-bottom: 0.1rem solid white !important;
+		}
+	}
+	.seventv-emote-menu-emote-list-section {
+		margin-top: 1em;
+		margin-left: 1em;
+	}
+	.seventv-emote-menu-category-header {
+		display: flex;
+		width: 100%;
+		justify-content: center;
+		font-size: 1.65rem;
 
-    border-style: solid;
-    border-bottom-width: 0.1rem;
-    border-color: white;
-  }
-  .seventv-emote-menu-emote-list {
-    display: flex;
-    flex-wrap: wrap;
+		border-style: solid;
+		border-bottom-width: 0.1rem;
+		border-color: white;
+	}
+	.seventv-emote-menu-emote-list {
+		display: flex;
+		flex-wrap: wrap;
 
-    margin-top: 1em;
-    margin-right: 0.25em;
-    margin-left: 1.25em;
-    margin-bottom: 1em;
+		margin-top: 1em;
+		margin-right: 0.25em;
+		margin-left: 1.25em;
+		margin-bottom: 1em;
 
-    span {
-      margin-right: 0.2em;
-      margin-left: 0.2em;
-      margin-top: 0.1em;
-      margin-bottom: 0.1em;
-    }
-  }
-  .seventv-emote-menu-search {
-    background-color: var(--seventv-background-color);
-    display: flex;
-    flex-direction: row;
-    justify-content: stretch;
-    padding: 0;
-    margin: 0;
-    input {
-      width: 100%;
-      height: 3em;
-      color: white;
-      border-color: white;
-      border-width: 0.1rem;
-      border-style: solid;
-      border-radius: 0 0 0.4rem 0.4rem;
-      background-color: var(--seventv-color-background-1);
-      padding: 0.25em 0.5em;
-      transition: all 0.2s ease-in-out;
+		span {
+			margin-right: 0.2em;
+			margin-left: 0.2em;
+			margin-top: 0.1em;
+			margin-bottom: 0.1em;
+		}
+	}
+	.seventv-emote-menu-search {
+		background-color: var(--seventv-background-color);
+		display: flex;
+		flex-direction: row;
+		justify-content: stretch;
+		padding: 0;
+		margin: 0;
+		input {
+			width: 100%;
+			height: 3em;
+			color: white;
+			border-color: white;
+			border-width: 0.1rem;
+			border-style: solid;
+			border-radius: 0 0 0.4rem 0.4rem;
+			background-color: var(--seventv-color-background-1);
+			padding: 0.25em 0.5em;
+			transition: all 0.2s ease-in-out;
 
-      &:focus {
-        outline: none !important;
-        border: 0.1rem solid rgb(0, 195, 255);
-        box-shadow: 0 0 1rem rgb(0, 195, 255) !important;
-      }
-    }
-  }
+			&:focus {
+				outline: none !important;
+				border: 0.1rem solid rgb(0, 195, 255);
+				box-shadow: 0 0 1rem rgb(0, 195, 255) !important;
+			}
+		}
+	}
 
-  & *::-webkit-scrollbar {
-    width: 0.5rem;
-  }
-  & *::-webkit-scrollbar-track {
-    background-color: var(--seventv-color-background-0);
-  }
-  & *::-webkit-scrollbar-thumb {
-    background-color: var(--seventv-color-background-1);
-    border-radius: 0.2rem;
-    border: 0 solid transparent;
-  }
+	& *::-webkit-scrollbar {
+		width: 0.5rem;
+	}
+	& *::-webkit-scrollbar-track {
+		background-color: var(--seventv-color-background-0);
+	}
+	& *::-webkit-scrollbar-thumb {
+		background-color: var(--seventv-color-background-1);
+		border-radius: 0.2rem;
+		border: 0 solid transparent;
+	}
 }

--- a/src/Style/Style.scss
+++ b/src/Style/Style.scss
@@ -15,231 +15,229 @@ $bgColorLight1: lighten($bgColorLight0, 5);
 $bgColorLightHighlight0: darken($bgColorLight0, 2.5);
 $bgColorLightTooltip: transparentize($bgColorLight0, 0.2);
 
-$primaryColor: #0288D1;
+$primaryColor: #0288d1;
 $accentColor: #b2ff59;
 
 .tw-root--theme-dark,
 ytd-app,
 yt-live-chat-app,
-div[id="contents"],
-div[id="content"]
-{
-	--seventv-text-color: white;
-	--seventv-color-background-0: #{$bgColorDark0};
-	--seventv-color-background-1: #{$bgColorDark1};
-	--seventv-color-background-hl0: #{$bgColorDarkHighlight0};
-	--seventv-color-tooltip: #{$bgColorDarkTooltip};
-	--seventv-primary-color: #{$primaryColor};
-	--seventv-accent-color: #{$accentColor};
+div[id='contents'],
+div[id='content'] {
+  --seventv-text-color: white;
+  --seventv-color-background-0: #{$bgColorDark0};
+  --seventv-color-background-1: #{$bgColorDark1};
+  --seventv-color-background-hl0: #{$bgColorDarkHighlight0};
+  --seventv-color-tooltip: #{$bgColorDarkTooltip};
+  --seventv-primary-color: #{$primaryColor};
+  --seventv-accent-color: #{$accentColor};
 }
 .tw-root--theme-light {
-	--seventv-text-color: black;
-	--seventv-color-background-0: #{$bgColorLight0};
-	--seventv-color-background-1: #{$bgColorLight1};
-	--seventv-color-tooltip: #{$bgColorLightTooltip};
-	--seventv-primary-color: #{$primaryColor};
-	--seventv-accent-color: #{$accentColor};
+  --seventv-text-color: black;
+  --seventv-color-background-0: #{$bgColorLight0};
+  --seventv-color-background-1: #{$bgColorLight1};
+  --seventv-color-tooltip: #{$bgColorLightTooltip};
+  --seventv-primary-color: #{$primaryColor};
+  --seventv-accent-color: #{$accentColor};
 }
 
 .seventv-overlay {
-	display: flex;
-	position: absolute;
-	top: 0;
-	left: 0;
-	right: 0;
-	bottom: 0;
-	background-color: transparent;
-	color: var(--seventv-text-color);
+  display: flex;
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: transparent;
+  color: var(--seventv-text-color);
 
-	pointer-events: none;
+  pointer-events: none;
 
-	.seventv-clickable-overlay-child {
-		pointer-events: all;
-	}
-	.seventv-overlay-main {
-		width: 100vw;
-		height: 100vh;
-		background-color: transparent;
-		z-index: 99999999;
-	}
+  .seventv-clickable-overlay-child {
+    pointer-events: all;
+  }
+  .seventv-overlay-main {
+    width: 100vw;
+    height: 100vh;
+    background-color: transparent;
+    z-index: 99999999;
+  }
 }
 
 .seventv-yt {
-	.seventv-emote {
-		margin: -0.5rem 0;
-		position: relative;
-		vertical-align: middle;
-	}
+  .seventv-emote {
+    margin: -0.5rem 0;
+    position: relative;
+    vertical-align: middle;
+  }
 }
 
 .chat-image-wrapper {
-	display: none;
+  display: none;
 }
 
 .emoji {
-	height: 1.95em !important;
-	width: auto !important;
+  height: 1.95em !important;
+  width: auto !important;
 }
 
 // Move the YouTube Slowmode countdown back over the Send button
 .yt-live-chat-message-input-renderer#countdown {
-	left: -73px;
+  left: -73px;
 }
 
 .seventv-message-context > :first-child {
-	margin-right: 0.25em;
+  margin-right: 0.25em;
 }
 
 .seventv-message-mentioned {
-	background-color: rgba(255, 0, 0, 0.25);
+  background-color: rgba(255, 0, 0, 0.25);
 }
 
 .seventv-text-fragment + .seventv-emote {
-	margin-right: 0.25em;
+  margin-right: 0.25em;
 }
 
 .seventv-emote + .seventv-text-fragment:not(.seventv-text-empty) {
-	margin-right: 0.25em;
+  margin-right: 0.25em;
 }
 
 .twitch-emote {
-	cursor: pointer;
+  cursor: pointer;
 }
 
 .seventv-mention {
-	font-weight: bold;
+  font-weight: bold;
 }
 
 .seventv-emote.seventv-zerowidth {
-	z-index: 50;
+  z-index: 50;
 }
 
 .seventv-emote.seventv-next-is-zerowidth {
-	span {
-		position: absolute;
-		width: 0px;
-	}
+  span {
+    position: absolute;
+    width: 0px;
+  }
 }
 
 .seventv-emote.seventv-emote-unlisted {
-	filter: blur(0.8rem);
+  filter: blur(0.8rem);
 }
 
 .seventv-static-emote {
-	border-radius: 9000px; 
-	position: absolute;
-	top: 0; 
-	left: 0;
+  border-radius: 9000px;
+  position: absolute;
+  top: 0;
+  left: 0;
 }
 
 .seventv-menu-button {
-	cursor: pointer !important;
-	display: flex;
-	justify-content: center;
-	width: var(--button-size-default, var(--yt-icon-width));
-	height: var(--button-size-default, var(--yt-icon-height));
-	position: relative;
+  cursor: pointer !important;
+  display: flex;
+  justify-content: center;
+  width: var(--button-size-default, var(--yt-icon-width));
+  height: var(--button-size-default, var(--yt-icon-height));
+  position: relative;
 
-	%tooltip {
-		background-color: var(--color-text-base, var(--seventv-color-background-0));
-		color: var(--color-text-tooltip, var(--seventv-text-color));
-		text-align: center;		
-		padding: 2px 0;
-		border-radius: 4px;
-		font-weight: 600;
-		
-		position: absolute;
-		width: 7em;
-		left: 50%;
-		margin-left: -3.5em;
-		z-index: 9999;
-	
-		visibility: hidden;
-		opacity: 0;
-		transition:opacity 0.1s ease-in 0.2s;
-	
-		&:after {
-			content: "";
-			position: absolute;
-			left: 50%;
-			margin-left: -5px;
-			border-width: 5px;
-			border-style: solid;
-			pointer-events: none;
-		}
-	}
+  %tooltip {
+    background-color: var(--color-text-base, var(--seventv-color-background-0));
+    color: var(--color-text-tooltip, var(--seventv-text-color));
+    text-align: center;
+    padding: 2px 0;
+    border-radius: 4px;
+    font-weight: 600;
 
-	.tooltip-under {
-		@extend %tooltip;
-		top: 135%;
+    position: absolute;
+    width: 7em;
+    left: 50%;
+    margin-left: -3.5em;
+    z-index: 9999;
 
-		&:after {
-			bottom: 100%;
-			border-color: transparent transparent var(--color-text-base, var(--seventv-color-background-0)) transparent;
-		}
-	}
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity 0.1s ease-in 0.2s;
 
-	.tooltip-over {
-		@extend %tooltip;
-		bottom: 135%;
+    &:after {
+      content: '';
+      position: absolute;
+      left: 50%;
+      margin-left: -5px;
+      border-width: 5px;
+      border-style: solid;
+      pointer-events: none;
+    }
+  }
 
-		&:after {
-			top: 100%;
-			border-color: var(--color-text-base, var(--seventv-color-background-0)) transparent transparent transparent;
-		}
-	}
+  .tooltip-under {
+    @extend %tooltip;
+    top: 135%;
 
+    &:after {
+      bottom: 100%;
+      border-color: transparent transparent var(--color-text-base, var(--seventv-color-background-0)) transparent;
+    }
+  }
 
-	&:hover {
-		border-radius: 0.4rem;
-		background-color: var(--color-background-button-text-hover);
-		color: var(--color-fill-button-icon-hover);
+  .tooltip-over {
+    @extend %tooltip;
+    bottom: 135%;
 
-		%tooltip {
-			visibility: visible;
-			opacity: 1;
-		  }
-	}
+    &:after {
+      top: 100%;
+      border-color: var(--color-text-base, var(--seventv-color-background-0)) transparent transparent transparent;
+    }
+  }
 
-	button {
-		border: 0;
-		background: transparent;
-		color: white;
-		width: var(--button-size-default, var(--yt-icon-width));
-		height: var(--button-size-default, var(--yt-icon-height));
-		padding: var(--yt-icon-padding, 0.5rem);
+  &:hover {
+    border-radius: 0.4rem;
+    background-color: var(--color-background-button-text-hover);
+    color: var(--color-fill-button-icon-hover);
 
-		&:hover {
-			color: var(--color-fill-button-icon-hover);
-		}
-	}
+    %tooltip {
+      visibility: visible;
+      opacity: 1;
+    }
+  }
 
-	.logo {
-		background-color: var(--color-fill-button-icon, var(--yt-live-chat-secondary-text-color));
-  		width: 100%;
-  		height: 100%;
-		mask-size: contain;
-		cursor: pointer;
-  		-webkit-mask-size: contain;
-	}
+  button {
+    border: 0;
+    background: transparent;
+    color: white;
+    width: var(--button-size-default, var(--yt-icon-width));
+    height: var(--button-size-default, var(--yt-icon-height));
+    padding: var(--yt-icon-padding, 0.5rem);
+
+    &:hover {
+      color: var(--color-fill-button-icon-hover);
+    }
+  }
+
+  .logo {
+    background-color: var(--color-fill-button-icon, var(--yt-live-chat-secondary-text-color));
+    width: 100%;
+    height: 100%;
+    mask-size: contain;
+    cursor: pointer;
+    -webkit-mask-size: contain;
+  }
 }
 
 .seventv-badge-list {
-	img {
-		height: 1.8rem;
-	}
+  img {
+    height: 1.8rem;
+  }
 }
 
 // Base paint style
 
 body:not(.seventv-no-paints) [data-seventv-paint] {
-	background-clip: text !important;
-	background-size: cover !important;
-	-webkit-background-clip: text !important;
-	-webkit-text-fill-color: transparent;
-	background-color: currentColor;
+  background-clip: text !important;
+  background-size: cover !important;
+  -webkit-background-clip: text !important;
+  -webkit-text-fill-color: transparent;
+  background-color: currentColor;
 
-	.chat-author__intl-login {
-		opacity: unset !important;
-	}
+  .chat-author__intl-login {
+    opacity: unset !important;
+  }
 }

--- a/src/Style/Style.scss
+++ b/src/Style/Style.scss
@@ -23,221 +23,221 @@ ytd-app,
 yt-live-chat-app,
 div[id='contents'],
 div[id='content'] {
-  --seventv-text-color: white;
-  --seventv-color-background-0: #{$bgColorDark0};
-  --seventv-color-background-1: #{$bgColorDark1};
-  --seventv-color-background-hl0: #{$bgColorDarkHighlight0};
-  --seventv-color-tooltip: #{$bgColorDarkTooltip};
-  --seventv-primary-color: #{$primaryColor};
-  --seventv-accent-color: #{$accentColor};
+	--seventv-text-color: white;
+	--seventv-color-background-0: #{$bgColorDark0};
+	--seventv-color-background-1: #{$bgColorDark1};
+	--seventv-color-background-hl0: #{$bgColorDarkHighlight0};
+	--seventv-color-tooltip: #{$bgColorDarkTooltip};
+	--seventv-primary-color: #{$primaryColor};
+	--seventv-accent-color: #{$accentColor};
 }
 .tw-root--theme-light {
-  --seventv-text-color: black;
-  --seventv-color-background-0: #{$bgColorLight0};
-  --seventv-color-background-1: #{$bgColorLight1};
-  --seventv-color-tooltip: #{$bgColorLightTooltip};
-  --seventv-primary-color: #{$primaryColor};
-  --seventv-accent-color: #{$accentColor};
+	--seventv-text-color: black;
+	--seventv-color-background-0: #{$bgColorLight0};
+	--seventv-color-background-1: #{$bgColorLight1};
+	--seventv-color-tooltip: #{$bgColorLightTooltip};
+	--seventv-primary-color: #{$primaryColor};
+	--seventv-accent-color: #{$accentColor};
 }
 
 .seventv-overlay {
-  display: flex;
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: transparent;
-  color: var(--seventv-text-color);
+	display: flex;
+	position: absolute;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background-color: transparent;
+	color: var(--seventv-text-color);
 
-  pointer-events: none;
+	pointer-events: none;
 
-  .seventv-clickable-overlay-child {
-    pointer-events: all;
-  }
-  .seventv-overlay-main {
-    width: 100vw;
-    height: 100vh;
-    background-color: transparent;
-    z-index: 99999999;
-  }
+	.seventv-clickable-overlay-child {
+		pointer-events: all;
+	}
+	.seventv-overlay-main {
+		width: 100vw;
+		height: 100vh;
+		background-color: transparent;
+		z-index: 99999999;
+	}
 }
 
 .seventv-yt {
-  .seventv-emote {
-    margin: -0.5rem 0;
-    position: relative;
-    vertical-align: middle;
-  }
+	.seventv-emote {
+		margin: -0.5rem 0;
+		position: relative;
+		vertical-align: middle;
+	}
 }
 
 .chat-image-wrapper {
-  display: none;
+	display: none;
 }
 
 .emoji {
-  height: 1.95em !important;
-  width: auto !important;
+	height: 1.95em !important;
+	width: auto !important;
 }
 
 // Move the YouTube Slowmode countdown back over the Send button
 .yt-live-chat-message-input-renderer#countdown {
-  left: -73px;
+	left: -73px;
 }
 
 .seventv-message-context > :first-child {
-  margin-right: 0.25em;
+	margin-right: 0.25em;
 }
 
 .seventv-message-mentioned {
-  background-color: rgba(255, 0, 0, 0.25);
+	background-color: rgba(255, 0, 0, 0.25);
 }
 
 .seventv-text-fragment + .seventv-emote {
-  margin-right: 0.25em;
+	margin-right: 0.25em;
 }
 
 .seventv-emote + .seventv-text-fragment:not(.seventv-text-empty) {
-  margin-right: 0.25em;
+	margin-right: 0.25em;
 }
 
 .twitch-emote {
-  cursor: pointer;
+	cursor: pointer;
 }
 
 .seventv-mention {
-  font-weight: bold;
+	font-weight: bold;
 }
 
 .seventv-emote.seventv-zerowidth {
-  z-index: 50;
+	z-index: 50;
 }
 
 .seventv-emote.seventv-next-is-zerowidth {
-  span {
-    position: absolute;
-    width: 0px;
-  }
+	span {
+		position: absolute;
+		width: 0px;
+	}
 }
 
 .seventv-emote.seventv-emote-unlisted {
-  filter: blur(0.8rem);
+	filter: blur(0.8rem);
 }
 
 .seventv-static-emote {
-  border-radius: 9000px;
-  position: absolute;
-  top: 0;
-  left: 0;
+	border-radius: 9000px;
+	position: absolute;
+	top: 0;
+	left: 0;
 }
 
 .seventv-menu-button {
-  cursor: pointer !important;
-  display: flex;
-  justify-content: center;
-  width: var(--button-size-default, var(--yt-icon-width));
-  height: var(--button-size-default, var(--yt-icon-height));
-  position: relative;
+	cursor: pointer !important;
+	display: flex;
+	justify-content: center;
+	width: var(--button-size-default, var(--yt-icon-width));
+	height: var(--button-size-default, var(--yt-icon-height));
+	position: relative;
 
-  %tooltip {
-    background-color: var(--color-text-base, var(--seventv-color-background-0));
-    color: var(--color-text-tooltip, var(--seventv-text-color));
-    text-align: center;
-    padding: 2px 0;
-    border-radius: 4px;
-    font-weight: 600;
+	%tooltip {
+		background-color: var(--color-text-base, var(--seventv-color-background-0));
+		color: var(--color-text-tooltip, var(--seventv-text-color));
+		text-align: center;
+		padding: 2px 0;
+		border-radius: 4px;
+		font-weight: 600;
 
-    position: absolute;
-    width: 7em;
-    left: 50%;
-    margin-left: -3.5em;
-    z-index: 9999;
+		position: absolute;
+		width: 7em;
+		left: 50%;
+		margin-left: -3.5em;
+		z-index: 9999;
 
-    visibility: hidden;
-    opacity: 0;
-    transition: opacity 0.1s ease-in 0.2s;
+		visibility: hidden;
+		opacity: 0;
+		transition: opacity 0.1s ease-in 0.2s;
 
-    &:after {
-      content: '';
-      position: absolute;
-      left: 50%;
-      margin-left: -5px;
-      border-width: 5px;
-      border-style: solid;
-      pointer-events: none;
-    }
-  }
+		&:after {
+			content: '';
+			position: absolute;
+			left: 50%;
+			margin-left: -5px;
+			border-width: 5px;
+			border-style: solid;
+			pointer-events: none;
+		}
+	}
 
-  .tooltip-under {
-    @extend %tooltip;
-    top: 135%;
+	.tooltip-under {
+		@extend %tooltip;
+		top: 135%;
 
-    &:after {
-      bottom: 100%;
-      border-color: transparent transparent var(--color-text-base, var(--seventv-color-background-0)) transparent;
-    }
-  }
+		&:after {
+			bottom: 100%;
+			border-color: transparent transparent var(--color-text-base, var(--seventv-color-background-0)) transparent;
+		}
+	}
 
-  .tooltip-over {
-    @extend %tooltip;
-    bottom: 135%;
+	.tooltip-over {
+		@extend %tooltip;
+		bottom: 135%;
 
-    &:after {
-      top: 100%;
-      border-color: var(--color-text-base, var(--seventv-color-background-0)) transparent transparent transparent;
-    }
-  }
+		&:after {
+			top: 100%;
+			border-color: var(--color-text-base, var(--seventv-color-background-0)) transparent transparent transparent;
+		}
+	}
 
-  &:hover {
-    border-radius: 0.4rem;
-    background-color: var(--color-background-button-text-hover);
-    color: var(--color-fill-button-icon-hover);
+	&:hover {
+		border-radius: 0.4rem;
+		background-color: var(--color-background-button-text-hover);
+		color: var(--color-fill-button-icon-hover);
 
-    %tooltip {
-      visibility: visible;
-      opacity: 1;
-    }
-  }
+		%tooltip {
+			visibility: visible;
+			opacity: 1;
+		}
+	}
 
-  button {
-    border: 0;
-    background: transparent;
-    color: white;
-    width: var(--button-size-default, var(--yt-icon-width));
-    height: var(--button-size-default, var(--yt-icon-height));
-    padding: var(--yt-icon-padding, 0.5rem);
+	button {
+		border: 0;
+		background: transparent;
+		color: white;
+		width: var(--button-size-default, var(--yt-icon-width));
+		height: var(--button-size-default, var(--yt-icon-height));
+		padding: var(--yt-icon-padding, 0.5rem);
 
-    &:hover {
-      color: var(--color-fill-button-icon-hover);
-    }
-  }
+		&:hover {
+			color: var(--color-fill-button-icon-hover);
+		}
+	}
 
-  .logo {
-    background-color: var(--color-fill-button-icon, var(--yt-live-chat-secondary-text-color));
-    width: 100%;
-    height: 100%;
-    mask-size: contain;
-    cursor: pointer;
-    -webkit-mask-size: contain;
-  }
+	.logo {
+		background-color: var(--color-fill-button-icon, var(--yt-live-chat-secondary-text-color));
+		width: 100%;
+		height: 100%;
+		mask-size: contain;
+		cursor: pointer;
+		-webkit-mask-size: contain;
+	}
 }
 
 .seventv-badge-list {
-  img {
-    height: 1.8rem;
-  }
+	img {
+		height: 1.8rem;
+	}
 }
 
 // Base paint style
 
 body:not(.seventv-no-paints) [data-seventv-paint] {
-  background-clip: text !important;
-  background-size: cover !important;
-  -webkit-background-clip: text !important;
-  -webkit-text-fill-color: transparent;
-  background-color: currentColor;
+	background-clip: text !important;
+	background-size: cover !important;
+	-webkit-background-clip: text !important;
+	-webkit-text-fill-color: transparent;
+	background-color: currentColor;
 
-  .chat-author__intl-login {
-    opacity: unset !important;
-  }
+	.chat-author__intl-login {
+		opacity: unset !important;
+	}
 }


### PR DESCRIPTION
Fixes:
- Icons on the Emote Menu Tabs not centered vertically
- Styled Scrollbar on the emote-menu-scrollable
- Searchbox Input was affected differently between Twitch.tv & Youtube. Settled on making the parent div of the input a flexbox with `justify-content: stretch;`
- Made the border-radius only rounded for the Menu's corners, instead of every element in the Menu's corner.

Let me know of any issues you find with this pr! I'll make sure to fix them asap.
It's tested on both chrome & firefox.
Appreciate it!

-Jimmy