### PR TITLE
Add `ApolloCallbackDecorator` for Twitch

### DIFF
--- a/src/Sites/twitch.tv/Runtime/ApolloCallbackDecorator.ts
+++ b/src/Sites/twitch.tv/Runtime/ApolloCallbackDecorator.ts
@@ -1,0 +1,95 @@
+import { Twitch } from 'src/Sites/twitch.tv/Util/Twitch';
+import { TwitchPageScript } from 'src/Sites/twitch.tv/twitch';
+
+export class ApolloCallbackDecorator {
+	DECORATED_OPERATION_CALLBACKS = new Map<string, Function>([
+		[
+			Twitch.ApolloOperationNames.CurrentUserBannedStatus,
+			(data: any, originalCallback: Function) => {
+				// banStatus is null if the user is not banned
+				if (!data.result.channel.self.banStatus) {
+					setTimeout(() => {
+						const chatInputButtonsContainerElement =
+							document.querySelector(
+								Twitch.Selectors.ChatInputButtonsContainer
+							) as HTMLElement;
+						this.page.site.embeddedUI.embedChatButton(
+							chatInputButtonsContainerElement
+						);
+					}, 100);
+				}
+
+				// Call the original callback to continue the Apollo operation
+				originalCallback(data);
+			},
+		],
+	]);
+
+	constructor(private page: TwitchPageScript) {
+		// IIFE which sets up an interval timer to check for the Apollo client
+		// once found, the interval is cleared and the Apollo callbacks are decorated
+		(function hooked(
+			win: any,
+			apolloCallbackDecorator: ApolloCallbackDecorator
+		) {
+			let detectionInterval: any;
+			const findApolloClient = () => {
+				if (win.__APOLLO_CLIENT__) {
+					clearInterval(detectionInterval);
+					// another IIFE which decorates the Apollo callbacks, tries
+					// every 500ms for 5 seconds or until all callbacks are decorated
+					(() => {
+						let decoratorInterval: any;
+						decoratorInterval = global.setInterval(() => {
+							let allDecorated: boolean =
+								apolloCallbackDecorator.decorateCallbacks();
+							if (allDecorated) {
+								clearInterval(decoratorInterval);
+							}
+						}, 500);
+						setTimeout(
+							() => clearInterval(decoratorInterval),
+							5000
+						);
+					})();
+				}
+			};
+			detectionInterval = global.setInterval(findApolloClient, 1000);
+		})(window, this);
+	}
+
+	decorateCallbacks() {
+		const watches = this.getWatches();
+		let allDecorated = true;
+
+		for (const [operationName, decoratedCallbackFunction] of this
+			.DECORATED_OPERATION_CALLBACKS) {
+			const watch: any = watches.find(
+				(x: any) => x['query'][operationName]
+			);
+
+			if (!watch) {
+				allDecorated = false;
+				continue;
+			}
+
+			if (!watch['hasOverriddenCallback']) {
+				// set a flag to make sure we dont override the callback more than once
+				watch['hasOverriddenCallback'] = true;
+
+				const originalCallback: any = watch.callback;
+				watch.callback = (data: any) => {
+					decoratedCallbackFunction(data, originalCallback);
+				};
+			}
+		}
+
+		return allDecorated;
+	}
+
+	private getWatches() {
+		const apolloClient = (window as any).__APOLLO_CLIENT__;
+		const watches: any[] = Array.from(apolloClient['cache']['watches']);
+		return watches;
+	}
+}

--- a/src/Sites/twitch.tv/Util/Twitch.ts
+++ b/src/Sites/twitch.tv/Util/Twitch.ts
@@ -244,6 +244,11 @@ export namespace Twitch {
 		export const ChatMessageTimestamp = '.chat-line__timestamp';
 	}
 
+	// https://github.com/daylamtayari/Twitch-GQL/blob/master/Operation-Hashes.md
+	export namespace ApolloOperationNames {
+		export const CurrentUserBannedStatus = 'CurrentUserBannedStatus';
+	}
+
 
 	export type FindReactInstancePredicate = (node: any) => boolean;
 	export type AnyPureComponent = React.PureComponent & { [x: string]: any; };

--- a/src/Sites/twitch.tv/twitch.tsx
+++ b/src/Sites/twitch.tv/twitch.tsx
@@ -13,6 +13,7 @@ import { MessagePatcher } from 'src/Sites/twitch.tv/Util/MessagePatcher';
 import type { EventAPI } from 'src/Global/Events/EventAPI';
 import { TwitchVideoChatListener } from 'src/Sites/twitch.tv/Runtime/VideoChatListener';
 import { BaseTwitchChatListener } from 'src/Sites/twitch.tv/Runtime/BaseChatListener';
+import { ApolloCallbackDecorator } from 'src/Sites/twitch.tv/Runtime/ApolloCallbackDecorator';
 
 export class TwitchPageScript {
 	site = new SiteApp();
@@ -20,6 +21,7 @@ export class TwitchPageScript {
 	inputManager = inputManager = new InputManager(this);
 	avatarManager = new AvatarManager(this);
 	banSliderManager = new BanSliderManager(this);
+	ApolloCallbackDecorator = new ApolloCallbackDecorator(this);
 
 	currentChannel = '';
 	currentVideo = '';


### PR DESCRIPTION
- Adds a new concept to allow decoration of operation call-backs
- Add an operation call-back decorator for `CurrentUserBannedStatus`

Not a fan of querying the `watches` in an interval until they've all been found and their call-backs decorated, but I'm not sure of an easier way to do this, open to suggestions.   Also not sure if there's a much easier way to do this without hooking into the underlying Apollo client twitch uses, would be interested to hear those options.

Video example:
https://user-images.githubusercontent.com/22506439/191875122-375e45c6-60a7-40e1-b945-877aafc8e4fa.mp4

I think some other people may benefit from this, I see #296 & #254 

Tested in: Chrome, Firefox