### PR TITLE
Added null check to prevent crash in the emote autocomplete.

### DIFF
--- a/src/Sites/twitch.tv/twitch.tsx
+++ b/src/Sites/twitch.tv/twitch.tsx
@@ -237,7 +237,7 @@ export class TwitchPageScript {
 			//override the srcSet if the emote is inserted by seventv
 			matches.forEach((m) => {
 				const elem = m.element[0];
-				if (elem.key.startsWith('emote-img-seventv')) {
+				if (elem?.key.startsWith('emote-img-seventv')) {
 					m.element[0].props.children.props.srcSet = store.getEmote(elem.key.substring(18))?.urls.reduce((prev, current) =>
 					`${prev} ${current[1]} ${current[0]}x,`
 				, '');


### PR DESCRIPTION
Fix for issue #291 

Steps to reproduce issue:
-Enable FFZ and 7TV
-Refresh a channel page
-Attempt to use the emote autocomplete feature
-Occasionally the chat input will crash and disappear (%50 of the time for me)

Not sure if other issues arise under these conditions, but this PR prevents the chat input from crashing.