### PR TITLE
EmoteMenu: native toggle button

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,5 +1,6 @@
 ### Version 3.0.1.1000
 
+-   Added a button to toggle the native Twitch Emote Menu
 -   Fixed an issue which caused duplicate colon-complete matches with FFZ
 -   Fixed an issue that caused tab-completion to break with FFZ
 

--- a/locale/en_US.yaml
+++ b/locale/en_US.yaml
@@ -93,3 +93,6 @@ onboarding:
     button_done: Done
     button_join: Join
     button_review: Review
+
+emote_menu:
+    native: Open Native Menu

--- a/src/site/site.ts
+++ b/src/site/site.ts
@@ -5,6 +5,7 @@ import App from "@/site/App.vue";
 import { apolloClient } from "@/apollo/apollo";
 import { TextPaintDirective } from "@/directive/TextPaintDirective";
 import { TooltipDirective } from "@/directive/TooltipDirective";
+import { setupI18n } from "@/i18n";
 import { ApolloClients } from "@vue/apollo-composable";
 
 const appID = Date.now().toString();
@@ -62,6 +63,7 @@ app.provide(SITE_ASSETS_URL, extensionOrigin + "assets");
 app.provide(SITE_EXT_OPTIONS_URL, extensionOrigin + "index.html");
 
 app.use(createPinia())
+	.use(setupI18n())
 	.directive("tooltip", TooltipDirective)
 	.directive("cosmetic-paint", TextPaintDirective)
 	.mount("#seventv-root");

--- a/src/site/twitch.tv/modules/emote-menu/EmoteMenuTab.vue
+++ b/src/site/twitch.tv/modules/emote-menu/EmoteMenuTab.vue
@@ -1,6 +1,12 @@
 <template>
 	<div class="emote-area-container">
 		<UiScrollable class="scroll-area">
+			<!-- Native Menu Toggle -->
+			<div v-if="provider === 'TWITCH'" class="native-menu-toggle" @click="emit('toggle-native-menu')">
+				<Logo provider="TWITCH" />
+				<span v-t="'emote_menu.native'" />
+			</div>
+
 			<div class="emote-area">
 				<div v-for="es of sortedSets" :key="es.id" v-memo="[ctx.filter, es.emotes, selected]">
 					<EmoteMenuSet
@@ -61,6 +67,7 @@ const emit = defineEmits<{
 	(event: "emote-clicked", emote: SevenTV.ActiveEmote): void;
 	(event: "provider-visible", state: boolean): void;
 	(event: "toggle-settings"): void;
+	(event: "toggle-native-menu"): void;
 }>();
 
 const ctx = useEmoteMenuContext();
@@ -151,6 +158,29 @@ watch(() => [ctx.filter, sets, cosmetics.emoteSets], filterSets, {
 .scroll-area {
 	width: 28rem;
 	flex-shrink: 0;
+}
+
+.native-menu-toggle {
+	display: inline-block;
+	text-align: center;
+	grid-template-columns: 3rem 1fr;
+	width: 100%;
+	padding: 0.25rem 1rem;
+	cursor: pointer;
+
+	transition: background 0.2s ease-in-out;
+
+	svg,
+	span {
+		display: inline-block;
+		vertical-align: middle;
+		font-size: 1.25rem;
+		margin: 0.5rem;
+	}
+
+	&:hover {
+		background: hsla(0deg, 0%, 50%, 6%);
+	}
 }
 
 .sidebar {


### PR DESCRIPTION
Adding a button under the Twitch tab of the emote menu, to toggle the native twitch menu. (as a workaround for seeing locked emotes)