### PR TITLE
Contextual Onboarding Upgrade Popup

### DIFF
--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -36,8 +36,15 @@ chrome.runtime.onInstalled.addListener(() => {
 	});
 });
 
+// On-upgrade onboarding (2.x -> 3.x)
+const newTabs = new Set<number>();
+chrome.tabs.onCreated.addListener((t) => {
+	if (typeof t.id !== "number") return;
+
+	newTabs.add(t.id);
+});
 chrome.tabs.onUpdated.addListener((_, i, t) => {
-	if (!i.status || !t.url) return;
+	if (!i.status || !t.url || !t.id || !newTabs.has(t.id)) return;
 
 	const url = new URL(t.url);
 	if (url.host !== "www.twitch.tv") return;
@@ -54,6 +61,7 @@ chrome.tabs.onUpdated.addListener((_, i, t) => {
 		}
 		chrome.storage.local.remove("yt_permissions_requested");
 	});
+	newTabs.delete(t.id);
 });
 
 // Register content scripts


### PR DESCRIPTION
Making the upgrade-driven onboarding popup only appear when the user is interacting with twitch.tv (ie opening a new twitch tab, or navigating twitch in any way)