### PR TITLE
Improve Chat Unbuffering

### DIFF
--- a/src/site/global/settings/control/FormSlider.vue
+++ b/src/site/global/settings/control/FormSlider.vue
@@ -4,7 +4,7 @@
 		<div class="seventv-slider" :class="{ 'show-thresold-name': !!thresoldName }" :thresold-name="thresoldName">
 			<input
 				:id="node.key"
-				v-model="modelValue"
+				v-model.number="setting"
 				type="range"
 				:min="node.options?.min"
 				:max="node.options?.max"
@@ -18,7 +18,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed, ref } from "vue";
 import { useConfig } from "@/composable/useSettings";
 
 const props = defineProps<{
@@ -26,12 +26,7 @@ const props = defineProps<{
 }>();
 
 const held = ref(false);
-const modelValue = ref("");
 const setting = useConfig<number>(props.node.key);
-
-watch(modelValue, (val) => {
-	setting.value = parseInt(val);
-});
 
 const thresoldName = computed(() => {
 	if (!props.node.options?.named_thresolds) return;

--- a/src/site/global/settings/control/FormSlider.vue
+++ b/src/site/global/settings/control/FormSlider.vue
@@ -4,7 +4,7 @@
 		<div class="seventv-slider" :class="{ 'show-thresold-name': !!thresoldName }" :thresold-name="thresoldName">
 			<input
 				:id="node.key"
-				v-model="setting"
+				v-model="modelValue"
 				type="range"
 				:min="node.options?.min"
 				:max="node.options?.max"
@@ -18,7 +18,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import { useConfig } from "@/composable/useSettings";
 
 const props = defineProps<{
@@ -26,7 +26,12 @@ const props = defineProps<{
 }>();
 
 const held = ref(false);
+const modelValue = ref("");
 const setting = useConfig<number>(props.node.key);
+
+watch(modelValue, (val) => {
+	setting.value = parseInt(val);
+});
 
 const thresoldName = computed(() => {
 	if (!props.node.options?.named_thresolds) return;


### PR DESCRIPTION
This improves the visual feedback when chat unbuffers after previously being paused, so that it looks like the chat instantly unbuffered while avoiding a page stall.

This also fixes an issue with the Slider settings control, which caused it to store values as strings rather integers. This led to smooth scrolling logic being used unnecessarily.