### PR TITLE
Improve some styling

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,7 +118,7 @@ jobs:
                   cp dist/mv2/manifest.json dist/manifest/manifest.mv2.json
                   cp dist/mv3/manifest.json dist/manifest/manifest.mv3.json
 
-            - name: "upload Artifact: Installable"
+            - name: "Upload Artifact: Installable"
               if: ${{ env.installable }}
               uses: actions/upload-artifact@v3
               with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
         name: WebExtension Lint, Build, Test
         runs-on: aws-runner
         env:
-            installable: ${{ !!secrets.WEB_EXTENSION_CRX }}
+            installable: ${{ secrets.WEB_EXTENSION_CRX != '' }}
         concurrency:
             group: ${{ github.workflow }}-ci-${{ github.ref }}
             cancel-in-progress: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,7 +42,7 @@ jobs:
         name: WebExtension Lint, Build, Test
         runs-on: aws-runner
         env:
-            installable: ${{ secrets.WEB_EXTENSION_CRX != '' }}
+            installable: ${{ secrets.WEB_EXTENSION_CRX }}
         concurrency:
             group: ${{ github.workflow }}-ci-${{ github.ref }}
             cancel-in-progress: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,8 @@ jobs:
     ci:
         name: WebExtension Lint, Build, Test
         runs-on: aws-runner
+        env:
+            installable: ${{ !!secrets.WEB_EXTENSION_CRX }}
         concurrency:
             group: ${{ github.workflow }}-ci-${{ github.ref }}
             cancel-in-progress: true
@@ -89,9 +91,7 @@ jobs:
 
             # CRX is Chromium installer
             - name: Create CRX (Chromium)
-              env:
-                  private_key: ${{ secrets.WEB_EXTENSION_CRX }}
-              if: ${{ env.private_key }}
+              if: ${{ env.installable }}
               uses: cardinalby/webext-buildtools-chrome-crx-action@v2
               with:
                   zipFilePath: dist/mv3.zip
@@ -100,9 +100,7 @@ jobs:
 
             # XPI is Firefox installer
             - name: Create XPI (Firefox)
-              env:
-                  private_key: ${{ secrets.WEB_EXTENSION_CRX }}
-              if: ${{ env.private_key }}
+              if: ${{ env.installable }}
               id: web-ext-build
               uses: kewisch/action-web-ext@v1
               with:
@@ -112,20 +110,30 @@ jobs:
 
             - name: Structure Files
               run: |
-                  mv ${{ steps.web-ext-build.outputs.target }} dist/ext.xpi
+                  if [ -f dist/ext.crx ]; then
+                      mv dist/ext.crx dist/ext.zip
+                  fi
 
                   mkdir -p dist/manifest
                   cp dist/mv2/manifest.json dist/manifest/manifest.mv2.json
                   cp dist/mv3/manifest.json dist/manifest/manifest.mv3.json
 
-            - name: Upload Build Artifact
+            - name: "upload Artifact: Installable"
+              if: ${{ env.installable }}
+              uses: actions/upload-artifact@v3
+              with:
+                  name: installable
+                  retention-days: 60
+                  path: |
+                      dist/ext.crx
+                      dist/ext.xpi
+
+            - name: "Upload Artifact: Unpacked"
               uses: actions/upload-artifact@v3
               with:
                   name: build
                   retention-days: 60
                   path: |
-                      dist/ext.crx
-                      dist/ext.xpi
                       dist/mv3.zip
                       dist/mv2.zip
 
@@ -148,6 +156,12 @@ jobs:
               uses: actions/download-artifact@v3
               with:
                   name: build
+                  path: ext
+
+            - name: Download Artifact
+              uses: actions/download-artifact@v3
+              with:
+                  name: installable
                   path: ext
 
             - name: File Names

--- a/src/site/twitch.tv/modules/chat/ChatController.vue
+++ b/src/site/twitch.tv/modules/chat/ChatController.vue
@@ -420,9 +420,9 @@ seventv-container.seventv-chat-list {
 		white-space: nowrap;
 		padding: 0.5em;
 		border-radius: 0.33em;
-		color: #fff;
-		background-color: rgba(0, 0, 0, 50%);
-		outline: 0.25rem solid var(--seventv-muted);
+		color: currentColor;
+		background-color: var(--seventv-background-transparent-1);
+		outline: 0.25rem solid var(--seventv-border-transparent-1);
 
 		span:nth-of-type(1) {
 			margin-right: 0.25rem;

--- a/src/site/twitch.tv/modules/chat/components/message/EmoteTooltip.vue
+++ b/src/site/twitch.tv/modules/chat/components/message/EmoteTooltip.vue
@@ -170,6 +170,7 @@ if (props.emote.data?.owner?.style?.color) {
 
 img.tooltip-emote {
 	margin-bottom: 1rem;
+	margin-top: 1rem;
 }
 
 svg.tooltip-emoji {
@@ -183,7 +184,6 @@ svg.tooltip-emoji {
 	flex: 1;
 	padding-bottom: 0.25rem;
 	margin-bottom: 0.25rem;
-	border-bottom: 0.1rem solid var(--seventv-muted);
 
 	> h3 {
 		font-weight: 600;
@@ -193,8 +193,7 @@ svg.tooltip-emoji {
 .divider {
 	width: 65%;
 	height: 0.01em;
-	background-color: currentColor;
-	opacity: 0.15;
+	background-color: var(--seventv-border-transparent-1);
 	margin-top: 0.5rem;
 	margin-bottom: 0.5rem;
 }

--- a/src/site/twitch.tv/modules/mod-logs/ModLogs.vue
+++ b/src/site/twitch.tv/modules/mod-logs/ModLogs.vue
@@ -2,7 +2,7 @@
 	<main class="seventv-mod-logs-container">
 		<div ref="handle" class="seventv-mod-logs-header">
 			<ModLogsIcon />
-			<h3>Mod Logs</h3>
+			<h3 style="font-size: 1.5rem">Mod Logs</h3>
 
 			<button @click="emit('close')">
 				<TwClose />
@@ -143,7 +143,7 @@ defineExpose({
 <style scoped lang="scss">
 main.seventv-mod-logs-container {
 	background: var(--seventv-background-transparent-1);
-	backdrop-filter: blur(0.25em);
+	backdrop-filter: blur(1rem);
 	outline: 0.01rem solid var(--seventv-border-transparent-1);
 	border-radius: 0.25rem;
 }


### PR DESCRIPTION
1. Makes the "Mod Logs" use the same amount of blur as the emote menu. (was very annoying)
2. Smaller "Mod Logs" text, so it looks better.
3. Gives some padding to the big emote image so it looks better
4. Adjusts the "Chat paused" popup thing to look better in light mode.
5. Gets rid of the pointless ugly line below the emote name

![image](https://user-images.githubusercontent.com/18615981/228061110-ec344212-5439-4a0c-bee6-c18fa60cb9b2.png)
![image](https://user-images.githubusercontent.com/18615981/228061137-3da94560-1be2-4716-b485-bd8aceef64b5.png)
![image](https://user-images.githubusercontent.com/18615981/228061317-cc3eddea-eaf3-4b04-9e48-1f9b2aefd5ae.png)
