### PR TITLE
Fix VOD chat crashing while the user is logged out

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -2,6 +2,7 @@
 
 -   Reply threads should now function properly
 -   Added an option to change how deleted messages appear
+-   Fixed an issue which caused VOD chat to crash for some users
 
 ### Version 3.0.2.1000
 

--- a/src/site/twitch.tv/modules/chat-vod/ChatVod.vue
+++ b/src/site/twitch.tv/modules/chat-vod/ChatVod.vue
@@ -1,9 +1,9 @@
 <template>
-	<template v-for="{ current, msg, timestamp } of messageRefs" :key="msg.id">
-		<Teleport v-if="current.current" :to="current.current">
+	<template v-for="messageRef of messageRefs" :key="messageRef.msg.id">
+		<Teleport v-if="messageRef && messageRef.current.current" :to="messageRef.current.current">
 			<div class="seventv-chat-vod-message-wrapper">
-				<span class="seventv-chat-vod-message-timestamp">{{ timestamp }}</span>
-				<UserMessage :msg="msg" :emotes="emotes.active" />
+				<span class="seventv-chat-vod-message-timestamp">{{ messageRef.timestamp }}</span>
+				<UserMessage :msg="messageRef.msg" :emotes="emotes.active" />
 			</div>
 		</Teleport>
 	</template>
@@ -33,7 +33,7 @@ interface CommentData {
 	badgeSets: Twitch.BadgeSets;
 	canCurrentUserBan: boolean;
 	canCurrentUserDelete: boolean;
-	currentUser: TwTypeUser;
+	currentUser?: TwTypeUser;
 	messageContext: {
 		author: {
 			id: string;
@@ -153,7 +153,6 @@ function isCommentData(data: any): data is CommentData {
 		data.badgeSets &&
 		data.canCurrentUserBan !== undefined &&
 		data.canCurrentUserDelete !== undefined &&
-		data.currentUser &&
 		data.messageContext &&
 		data.messageContext.author &&
 		data.messageContext.comment &&
@@ -164,7 +163,7 @@ function isCommentData(data: any): data is CommentData {
 function patchComments(comments: ReactExtended.ReactRuntimeElement[]): ReactExtended.ReactRuntimeElement[] {
 	const newList = [] as ReactExtended.ReactRuntimeElement[];
 
-	messageRefs.value.length = comments.length;
+	messageRefs.value.length = 0;
 	for (let i = 0; i < comments.length; i++) {
 		const c = comments[i];
 		if (!c) continue;


### PR DESCRIPTION
Also properly handle when messageRef's are undefined as this will cause an immediate crash due to the destructuring operator {}, which can happen when a condition is not met for a message to be considered valid, or when the array is oversized.