### PR TITLE
Fixed message ban state message from flickering

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,3 +1,7 @@
+### Untitled Version
+
+- Fixed an issue which caused flickering when hovering on a deleted message
+
 ### Version 3.0.3.1000
 
 - Disabled YouTube support temporarily due an issue with request pattern

--- a/src/site/twitch.tv/modules/chat/components/message/UserMessage.vue
+++ b/src/site/twitch.tv/modules/chat/components/message/UserMessage.vue
@@ -305,7 +305,7 @@ watchEffect(() => {
 
 	&:hover {
 		.seventv-chat-message-moderated {
-			display: none !important;
+			visibility: hidden;
 		}
 	}
 }


### PR DESCRIPTION
Fixes the ungodly flickering when hovering over a message ban state message sometimes.
Changed "display: none;" to "visibility: hidden"

Bug Issue:
![Screenshot](https://user-images.githubusercontent.com/76515905/230157195-edc7631f-548a-45d8-be4e-9367555afcc6.png)

Bug Video:
https://user-images.githubusercontent.com/76515905/230157080-ed58cdfd-dc35-46f9-a46c-729319c9449a.mp4