### PR TITLE
Fix setting controls not scrolling with the rest of the settings menu

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,7 +1,5 @@
 ### Version 3.0.4.7000
 
-**The changes listed here are not assigned to an official release**.
-
 -   Added hot-patching functionality to the extension
 -   Added chat rich embeds which allows twitch clips to preview in chat
 -   Added a "Copy Message" button

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,4 +1,4 @@
-### Untitled Version
+### Version 3.0.4.7000
 
 **The changes listed here are not assigned to an official release**.
 
@@ -6,7 +6,11 @@
 -   Added chat rich embeds which allows twitch clips to preview in chat
 -   Added a "Copy Message" button
 -   Added an option to show thumbnail previews of streams when hovering over channels on the sidebar
+-   Temporarily disabled the "Most Used Emotes" feature, pending a refactor. This fixes severe input lag experienced by some users
+-   Made some internal changes which may decrease memory usage for some users
+-   Fixed bad performance on colon-completion by limiting the amount of items shown
 -   Fixed an issue which caused flickering when hovering on a deleted message
+-   Fixed a compatibility issue with another extension, causing distorted scrolling behavior in the settings menu
 
 ### Version 3.0.3.1000
 

--- a/src/site/global/settings/SettingsNode.vue
+++ b/src/site/global/settings/SettingsNode.vue
@@ -18,7 +18,7 @@
 		<div v-if="node.custom && node.custom.gridMode === 'new-row'" class="content">
 			<component :is="node.custom.component" />
 		</div>
-		<div v-else class="control">
+		<div v-else class="seventv-settings-node-control">
 			<component :is="com" :node="node" />
 		</div>
 	</div>
@@ -127,18 +127,17 @@ const com = standard[props.node.type] ?? props.node.custom?.component;
 		margin: 0 1rem;
 	}
 
-	.control {
+	.seventv-settings-node-control {
 		display: grid;
 		justify-self: end;
 		align-items: start;
 		margin: 0.5rem 1rem;
 		grid-area: control;
-		position: unset;
 	}
 
 	@media (max-width: 60rem) {
 		.subtitle,
-		.control,
+		.seventv-settings-node-control,
 		.content {
 			display: none;
 		}
@@ -147,7 +146,7 @@ const com = standard[props.node.type] ?? props.node.custom?.component;
 			grid-template-rows: 1fr 1fr 1fr;
 			grid-template-rows: 1fr;
 			.subtitle,
-			.control,
+			.seventv-settings-node-control,
 			.content {
 				display: grid;
 			}

--- a/src/site/global/settings/SettingsNode.vue
+++ b/src/site/global/settings/SettingsNode.vue
@@ -133,6 +133,7 @@ const com = standard[props.node.type] ?? props.node.custom?.component;
 		align-items: start;
 		margin: 0.5rem 1rem;
 		grid-area: control;
+		position: unset;
 	}
 
 	@media (max-width: 60rem) {


### PR DESCRIPTION
My twitch has an inline style tag that sets `.control { position: absolute; } `, which results in the settings menu being unusuable.

I thought it was a compatibility issue as there's no open Issue about that, so I disabled all other twitch extensions and that didn't fix the issue. This is quite a serious issue and since nobody else reported it I guess it's an edge case with my system.

Anyway, this fix is just a single line of css that shouldn't conflict with anything else. I didn't bother to create an open issue for it, I hope that's not a problem.

For reference, this is what it looks like when I scroll down in the settings:

![image](https://user-images.githubusercontent.com/3987753/230221854-6eb8f7e0-ca13-4e02-b2e2-51f59e8678f8.png)
![image](https://user-images.githubusercontent.com/3987753/230221871-856f4587-7e68-4641-bba0-1e92799dc674.png)
