### PR TITLE
Add 'Copy' Icon to chat messages, Add tooltip to message icons

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -7,7 +7,7 @@
 
 ### Version 3.0.3.1000
 
-- Disabled YouTube support temporarily due an issue with request pattern
+-   Disabled YouTube support temporarily due an issue with request pattern
 
 ### Version 3.0.2.3000
 
@@ -16,7 +16,6 @@
 -   Fixed the Most Used Emotes tab ignoring visibility setting
 -   Fixed sub emotes not showing in colon-complete while FFZ is enabled
 -   Fixed an issue which caused VOD chat to crash for some users
-
 
 ### Version 3.0.2.2000
 

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -4,6 +4,7 @@
 
 -   Added hot-patching functionality to the extension
 -   Added chat rich embeds which allows twitch clips to preview in chat
+-   Added a "Copy Message" button
 -   Fixed an issue which caused flickering when hovering on a deleted message
 
 ### Version 3.0.3.1000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### Version 3.0.3
 
-- Disabled YouTube support temporarily due an issue with request pattern
+-   Disabled YouTube support temporarily due an issue with request pattern
 
 ### Version 3.0.2
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Improve your viewing experience on Twitch & YouTube with new features, emotes, vanity and performance.",
 	"private": true,
 	"version": "3.0.4",
-	"dev_version": "4.0",
+	"dev_version": "5.0",
 	"scripts": {
 		"start": "NODE_ENV=dev yarn build:dev && NODE_ENV=dev vite --mode dev",
 		"build:section:app": "vite build --config vite.config.ts",

--- a/src/assets/svg/icons/CopyIcon.vue
+++ b/src/assets/svg/icons/CopyIcon.vue
@@ -1,0 +1,8 @@
+<template>
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" width="1em" height="1em" fill="currentColor">
+        <!-- Font Awesome Pro 5.15.4 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) -->
+        <path 
+            d="M320 448v40c0 13.255-10.745 24-24 24H24c-13.255 0-24-10.745-24-24V120c0-13.255 10.745-24 24-24h72v296c0 30.879 25.121 56 56 56h168zm0-344V0H152c-13.255 0-24 10.745-24 24v368c0 13.255 10.745 24 24 24h272c13.255 0 24-10.745 24-24V128H344c-13.2 0-24-10.8-24-24zm120.971-31.029L375.029 7.029A24 24 0 0 0 358.059 0H352v96h96v-6.059a24 24 0 0 0-7.029-16.97z"
+        />
+    </svg>
+</template>

--- a/src/assets/svg/icons/CopyIcon.vue
+++ b/src/assets/svg/icons/CopyIcon.vue
@@ -1,8 +1,8 @@
 <template>
-    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" width="1em" height="1em" fill="currentColor">
-        <!-- Font Awesome Pro 5.15.4 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) -->
-        <path 
-            d="M320 448v40c0 13.255-10.745 24-24 24H24c-13.255 0-24-10.745-24-24V120c0-13.255 10.745-24 24-24h72v296c0 30.879 25.121 56 56 56h168zm0-344V0H152c-13.255 0-24 10.745-24 24v368c0 13.255 10.745 24 24 24h272c13.255 0 24-10.745 24-24V128H344c-13.2 0-24-10.8-24-24zm120.971-31.029L375.029 7.029A24 24 0 0 0 358.059 0H352v96h96v-6.059a24 24 0 0 0-7.029-16.97z"
-        />
-    </svg>
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512" width="1em" height="1em" fill="currentColor">
+		<!-- Font Awesome Pro 5.15.4 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license (Commercial License) -->
+		<path
+			d="M320 448v40c0 13.255-10.745 24-24 24H24c-13.255 0-24-10.745-24-24V120c0-13.255 10.745-24 24-24h72v296c0 30.879 25.121 56 56 56h168zm0-344V0H152c-13.255 0-24 10.745-24 24v368c0 13.255 10.745 24 24 24h272c13.255 0 24-10.745 24-24V128H344c-13.2 0-24-10.8-24-24zm120.971-31.029L375.029 7.029A24 24 0 0 0 358.059 0H352v96h96v-6.059a24 24 0 0 0-7.029-16.97z"
+		/>
+	</svg>
 </template>

--- a/src/site/twitch.tv/modules/chat/ChatModule.vue
+++ b/src/site/twitch.tv/modules/chat/ChatModule.vue
@@ -315,11 +315,11 @@ export const config = [
 		],
 		defaultValue: 1,
 	}),
-	declareConfig("chat.timestamp_with_seconds", "TOGGLE", {
-		path: ["Chat", "Style"],
-		label: "Timestamp Seconds",
-		hint: "If checked, timestamps in chat will also show seconds",
-		defaultValue: false,
+	declareConfig("chat.copy_icon_toggle", "TOGGLE", {
+		path: ["Chat", "Message Tools"],
+		label: "Copy Icon",
+		hint: "Show a 'Copy' icon when hovering over a chat message to copy the message",
+		defaultValue: true,
 	}),
 	declareConfig<boolean>("highlights.basic.mention", "TOGGLE", {
 		path: ["Highlights", "Built-In"],

--- a/src/site/twitch.tv/modules/chat/ChatModule.vue
+++ b/src/site/twitch.tv/modules/chat/ChatModule.vue
@@ -315,6 +315,12 @@ export const config = [
 		],
 		defaultValue: 1,
 	}),
+	declareConfig("chat.timestamp_with_seconds", "TOGGLE", {
+		path: ["Chat", "Style"],
+		label: "Timestamp Seconds",
+		hint: "If checked, timestamps in chat will also show seconds",
+		defaultValue: false,
+	}),
 	declareConfig("chat.copy_icon_toggle", "TOGGLE", {
 		path: ["Chat", "Message Tools"],
 		label: "Copy Icon",

--- a/src/site/twitch.tv/modules/chat/components/message/UserMessageButtons.vue
+++ b/src/site/twitch.tv/modules/chat/components/message/UserMessageButtons.vue
@@ -3,45 +3,22 @@
 		<div
 			v-if="showCopyIcon && !msg.moderation.deleted"
 			ref="copyButtonRef"
+			v-tooltip="'Copy'"
 			class="seventv-button"
 			@click="copyToast = true"
-			@mouseenter="
-				() => {
-					tooltipText = 'Copy';
-					show(copyButtonRef);
-				}
-			"
-			@mouseleave="hide()"
 		>
 			<CopyIcon />
 		</div>
 		<div
 			v-if="msg.pinnable && !msg.moderation.deleted"
 			ref="pinButtonRef"
+			v-tooltip="'Pin'"
 			class="seventv-button"
 			@click="pinPrompt = true"
-			@mouseenter="
-				() => {
-					tooltipText = 'Pin';
-					show(pinButtonRef);
-				}
-			"
-			@mouseleave="hide()"
 		>
 			<PinIcon />
 		</div>
-		<div
-			ref="replyButtonRef"
-			class="seventv-button"
-			@click="openReplyTray"
-			@mouseenter="
-				() => {
-					tooltipText = 'Reply';
-					show(replyButtonRef);
-				}
-			"
-			@mouseleave="hide()"
-		>
+		<div v-tooltip="'Reply'" class="seventv-button" @click="openReplyTray">
 			<component :is="msg.parent ? TwChatReply : ReplyIcon" />
 		</div>
 	</div>
@@ -77,12 +54,10 @@ import { ref } from "vue";
 import { ChatMessage } from "@/common/chat/ChatMessage";
 import { useFloatScreen } from "@/composable/useFloatContext";
 import { useConfig } from "@/composable/useSettings";
-import { useTooltip } from "@/composable/useTooltip";
 import CopyIcon from "@/assets/svg/icons/CopyIcon.vue";
 import PinIcon from "@/assets/svg/icons/PinIcon.vue";
 import ReplyIcon from "@/assets/svg/icons/ReplyIcon.vue";
 import TwChatReply from "@/assets/svg/twitch/TwChatReply.vue";
-import BadgeTooltip from "./BadgeTooltip.vue";
 import UserTag from "./UserTag.vue";
 import UiConfirmPrompt from "@/ui/UiConfirmPrompt.vue";
 import UiCopiedMessageToast from "@/ui/UiCopiedMessageToast.vue";
@@ -110,12 +85,6 @@ const tray = useTray("Reply", () => ({
 		: {}),
 }));
 
-const tooltipText = ref("");
-
-const { show, hide } = useTooltip(BadgeTooltip, {
-	alt: tooltipText,
-});
-
 const showCopyIcon = useConfig<boolean>("chat.copy_icon_toggle");
 const copyToast = ref(false);
 const copyButtonRef = ref<HTMLElement>();
@@ -130,8 +99,6 @@ const pinPromptContainer = useFloatScreen(pinButtonRef, {
 	enabled: () => pinPrompt.value,
 	middleware: [shift({ padding: 8 })],
 });
-
-const replyButtonRef = ref<HTMLElement>();
 
 function openReplyTray(): void {
 	tray.open();

--- a/src/site/twitch.tv/modules/chat/components/message/UserMessageButtons.vue
+++ b/src/site/twitch.tv/modules/chat/components/message/UserMessageButtons.vue
@@ -5,7 +5,12 @@
 			ref="copyButtonRef"
 			class="seventv-button"
 			@click="copyToast = true"
-			@mouseenter="() => { tooltipText = 'Copy'; show(copyButtonRef) }"
+			@mouseenter="
+				() => {
+					tooltipText = 'Copy';
+					show(copyButtonRef);
+				}
+			"
 			@mouseleave="hide()"
 		>
 			<CopyIcon />
@@ -15,16 +20,26 @@
 			ref="pinButtonRef"
 			class="seventv-button"
 			@click="pinPrompt = true"
-			@mouseenter="() => { tooltipText = 'Pin'; show(pinButtonRef) }"
+			@mouseenter="
+				() => {
+					tooltipText = 'Pin';
+					show(pinButtonRef);
+				}
+			"
 			@mouseleave="hide()"
 		>
 			<PinIcon />
 		</div>
-		<div 
+		<div
 			ref="replyButtonRef"
 			class="seventv-button"
 			@click="openReplyTray"
-			@mouseenter="() => { tooltipText = 'Reply'; show(replyButtonRef) }"
+			@mouseenter="
+				() => {
+					tooltipText = 'Reply';
+					show(replyButtonRef);
+				}
+			"
 			@mouseleave="hide()"
 		>
 			<component :is="msg.parent ? TwChatReply : ReplyIcon" />
@@ -34,11 +49,7 @@
 	<!-- Toast for Copy -->
 	<template v-if="copyToast && copyToastContainer">
 		<Teleport :to="copyToastContainer">
-			<UiCopiedMessageToast
-				title="Message Copied"
-				:body="msg.body"
-				@close="copyToast = false"
-			>
+			<UiCopiedMessageToast title="Message Copied" :body="msg.body" @close="copyToast = false">
 				Message from
 				<UserTag v-if="msg.author" :user="msg.author" /> has been copied
 			</UiCopiedMessageToast>
@@ -65,18 +76,18 @@
 import { ref } from "vue";
 import { ChatMessage } from "@/common/chat/ChatMessage";
 import { useFloatScreen } from "@/composable/useFloatContext";
-import CopyIcon from "@/assets/svg/icons/CopyIcon.vue"
+import { useConfig } from "@/composable/useSettings";
+import { useTooltip } from "@/composable/useTooltip";
+import CopyIcon from "@/assets/svg/icons/CopyIcon.vue";
 import PinIcon from "@/assets/svg/icons/PinIcon.vue";
 import ReplyIcon from "@/assets/svg/icons/ReplyIcon.vue";
 import TwChatReply from "@/assets/svg/twitch/TwChatReply.vue";
+import BadgeTooltip from "./BadgeTooltip.vue";
 import UserTag from "./UserTag.vue";
 import UiConfirmPrompt from "@/ui/UiConfirmPrompt.vue";
 import UiCopiedMessageToast from "@/ui/UiCopiedMessageToast.vue";
-import { useTooltip } from "@/composable/useTooltip";
-import BadgeTooltip from "./BadgeTooltip.vue";
 import { useTray } from "../tray/ChatTray";
 import { shift } from "@floating-ui/dom";
-import { useConfig } from "@/composable/useSettings";
 
 const props = defineProps<{
 	msg: ChatMessage;

--- a/src/ui/UiCopiedMessageToast.vue
+++ b/src/ui/UiCopiedMessageToast.vue
@@ -1,0 +1,58 @@
+<template>
+	<main ref="copiedMessageToastRef" class="seventv-copied-message-toast">
+		<div class="seventv-copied-message-toast-body">
+			<p v-if="message">{{ message }}</p>
+			<slot v-else />
+		</div>
+	</main>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import { onClickOutside } from "@vueuse/core";
+
+const copiedMessageToastRef = ref<HTMLElement>();
+const timeout = 1000;
+
+const props = defineProps<{
+	message?: string;
+	body: string;
+}>();
+
+const emit = defineEmits<{
+	(event: "close"): void;
+}>();
+
+onClickOutside(copiedMessageToastRef, () => {
+	emit("close");
+});
+
+function main(): void {
+	navigator.clipboard.writeText(props.body);
+	setTimeout(() => emit("close"), timeout);
+}
+
+main();
+</script>
+
+<style scoped lang="scss">
+main.seventv-copied-message-toast {
+	background: var(--seventv-background-transparent-1);
+	backdrop-filter: blur(1rem);
+	border: 0.15rem solid var(--seventv-border-transparent-1);
+	border-radius: 0.25rem;
+	max-width: 18rem;
+	z-index: 100;
+	opacity: 1;
+
+	.seventv-copied-message-toast-body {
+		padding: 0.5rem 1rem;
+		border-bottom: 0.1rem solid var(--seventv-border-transparent-1);
+		text-align: center;
+
+		p {
+			font-size: 1.25rem;
+		}
+	}
+}
+</style>

--- a/src/ui/UiCopiedMessageToast.vue
+++ b/src/ui/UiCopiedMessageToast.vue
@@ -12,11 +12,9 @@ import { ref } from "vue";
 import { onClickOutside } from "@vueuse/core";
 
 const copiedMessageToastRef = ref<HTMLElement>();
-const timeout = 1000;
 
-const props = defineProps<{
+defineProps<{
 	message?: string;
-	body: string;
 }>();
 
 const emit = defineEmits<{
@@ -26,13 +24,6 @@ const emit = defineEmits<{
 onClickOutside(copiedMessageToastRef, () => {
 	emit("close");
 });
-
-function main(): void {
-	navigator.clipboard.writeText(props.body);
-	setTimeout(() => emit("close"), timeout);
-}
-
-main();
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
## Two features added

### Feature 1
Toggleable 'Copy' icon to copy a chat message. Icon appears next to reply/pin icons:
![image](https://user-images.githubusercontent.com/69816894/230248974-130d7172-2a9b-4835-842d-f5e2a47c9932.png)

Clicking the icon copies the chat message and shows a toast for 1 second confirming the message was copied:
![image](https://user-images.githubusercontent.com/69816894/230249040-f794bc15-c3ed-478a-a926-6a6a85faf222.png)

**This copies purely the chat message, so the clipboard in the above example results in: "Hello"**

This feature is toggleable and true by default, a new subcategory named "Message tools" in "Chat" settings is added as I was unsure which subcategory this would fit in:
![image](https://user-images.githubusercontent.com/69816894/230248133-2622a2d1-1a84-4814-9f92-91aae7ec9896.png)

It is understandable if this feature is not approved as some chats may not appreciate easier copy pastas... but there are some chats who would be a fan of it. Let me know if I should remove feature 1 and just keep feature 2 as I believe feature 2 is useful.

### Feature 2
Tooltips for the reply/pin/copy icons on mouse hover:
![image](https://user-images.githubusercontent.com/69816894/230249128-400b61b8-6541-4024-b34b-828e5ae2966b.png)
![image](https://user-images.githubusercontent.com/69816894/230249152-a048d816-7c92-4de3-81fc-22838b06a9db.png)
![image](https://user-images.githubusercontent.com/69816894/230249172-7ce1e556-1ac3-46a2-a775-6f81ca81baa9.png)

This feature utilizes the "BadgeTooltip" component, so possibly rename BadgeTooltip to a more general name if this feature stays?