### PR TITLE
Performance Tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Improve your viewing experience on Twitch & YouTube with new features, emotes, vanity and performance.",
 	"private": true,
 	"version": "3.0.4",
-	"dev_version": "6.0",
+	"dev_version": "7.0",
 	"scripts": {
 		"start": "NODE_ENV=dev yarn build:dev && NODE_ENV=dev vite --mode dev",
 		"build:section:app": "vite build --config vite.config.ts",

--- a/src/site/twitch.tv/modules/chat-input/ChatInput.vue
+++ b/src/site/twitch.tv/modules/chat-input/ChatInput.vue
@@ -84,7 +84,7 @@ const historyLocation = ref(-1);
 
 const { ctrl: isCtrl, shift: isShift } = useMagicKeys();
 
-function findMatchingTokens(str: string, mode: "tab" | "colon" = "tab"): TabToken[] {
+function findMatchingTokens(str: string, mode: "tab" | "colon" = "tab", limit?: number): TabToken[] {
 	const usedTokens = new Set<string>();
 
 	const matches: TabToken[] = [];
@@ -154,6 +154,7 @@ function findMatchingTokens(str: string, mode: "tab" | "colon" = "tab"): TabToke
 	}
 
 	matches.sort((a, b) => a.priority + b.priority * (a.token.localeCompare(b.token) / 0.5));
+	if (typeof limit === "number" && matches.length > limit) matches.length = limit;
 
 	return matches;
 }
@@ -420,7 +421,7 @@ function getMatchesHook(this: unknown, native: ((...args: unknown[]) => object[]
 	const results = native?.call(this, str, ...args) ?? [];
 
 	const allEmotes = { ...cosmetics.emotes, ...emotes.active, ...emotes.emojis };
-	const tokens = findMatchingTokens(str.substring(1), "colon");
+	const tokens = findMatchingTokens(str.substring(1), "colon", 25);
 
 	for (let i = tokens.length - 1; i > -1; i--) {
 		const token = tokens[i].token;

--- a/src/site/twitch.tv/modules/chat/ChatList.vue
+++ b/src/site/twitch.tv/modules/chat/ChatList.vue
@@ -1,6 +1,6 @@
 <template>
 	<main ref="chatListEl" class="seventv-chat-list" :alternating-background="isAlternatingBackground">
-		<div v-for="msg of displayedMessages" :key="msg.sym" v-memo="[msg]" :msg-id="msg.id" class="seventv-message">
+		<div v-for="msg of displayedMessages" :key="msg.sym" :msg-id="msg.id" class="seventv-message">
 			<template v-if="msg.instance">
 				<component
 					:is="isModSliderEnabled && properties.isModerator && msg.author ? ModSlider : 'span'"

--- a/src/site/twitch.tv/modules/chat/components/message/Emote.vue
+++ b/src/site/twitch.tv/modules/chat/components/message/Emote.vue
@@ -6,6 +6,8 @@
 			:srcset="unload ? '' : processSrcSet(emote)"
 			:alt="emote.name"
 			:class="{ blur: hideUnlisted && emote.data?.listed === false }"
+			loading="lazy"
+			decoding="async"
 			@load="onImageLoad"
 			@mouseenter="onShowTooltip"
 			@mouseleave="hide()"

--- a/src/site/twitch.tv/modules/emote-menu/EmoteMenu.vue
+++ b/src/site/twitch.tv/modules/emote-menu/EmoteMenu.vue
@@ -32,7 +32,6 @@
 					v-for="(_, key) in visibleProviders"
 					v-show="key === activeProvider"
 					:key="key"
-					v-memo="[activeProvider === key, visibleProviders, ctx.filter]"
 					class="seventv-emote-menu-body"
 				>
 					<EmoteMenuTab

--- a/src/site/twitch.tv/modules/emote-menu/EmoteMenuModule.vue
+++ b/src/site/twitch.tv/modules/emote-menu/EmoteMenuModule.vue
@@ -96,7 +96,8 @@ export const config = [
 	declareConfig<boolean>("ui.emote_menu.most_used", "TOGGLE", {
 		path: ["Appearance", "Interface"],
 		label: "Emote Menu: Most Used Emotes",
-		hint: "Whether or not to display the emotes you type the most in the emote menu",
+		hint: "Whether or not to display the emotes you type the most in the emote menu (Temporarily disabled due to performance issues)",
+		disabledIf: () => true,
 		defaultValue: true,
 	}),
 	declareConfig<Set<string>>("ui.emote_menu.favorites", "NONE", {

--- a/src/site/twitch.tv/modules/emote-menu/EmoteMenuTab.vue
+++ b/src/site/twitch.tv/modules/emote-menu/EmoteMenuTab.vue
@@ -87,8 +87,11 @@ const cosmetics = useCosmetics(store.identity?.id ?? "");
 const visibleSets = reactive<Set<SevenTV.EmoteSet>>(new Set());
 const sortedSets = ref([] as SevenTV.EmoteSet[]);
 const favorites = useConfig<Set<string>>("ui.emote_menu.favorites");
-const usage = useConfig<Map<string, number>>("ui.emote_menu.usage");
-const shouldShowUsage = useConfig<boolean>("ui.emote_menu.most_used");
+// const usage = useConfig<Map<string, number>>("ui.emote_menu.usage");
+// const shouldShowUsage = useConfig<boolean>("ui.emote_menu.most_used");
+
+// "Most Used" is commented out pending refactor
+// Note the logic for favorites is also bad, though doesn't affect as many users
 
 function updateFavorites() {
 	return Array.from(favorites.value.values())
@@ -96,15 +99,15 @@ function updateFavorites() {
 		.filter((ae) => !!ae) as SevenTV.ActiveEmote[];
 }
 
-function updateUsage() {
-	if (!shouldShowUsage.value) return [];
-
-	return Array.from(usage.value.entries())
-		.sort((a, b) => b[1] - a[1])
-		.map((e) => emotes.find((ae) => ae.id === e[0]))
-		.filter((ae) => !!ae)
-		.slice(0, 50) as SevenTV.ActiveEmote[];
-}
+// function updateUsage() {
+// 	if (!shouldShowUsage.value) return [];
+//
+// 	return Array.from(usage.value.entries())
+// 		.sort((a, b) => b[1] - a[1])
+// 		.map((e) => emotes.find((ae) => ae.id === e[0]))
+// 		.filter((ae) => !!ae)
+// 		.slice(0, 50) as SevenTV.ActiveEmote[];
+// }
 
 if (props.provider === "FAVORITE") {
 	// create favorite set
@@ -114,19 +117,19 @@ if (props.provider === "FAVORITE") {
 		emotes: updateFavorites(),
 	} as SevenTV.EmoteSet));
 
-	const usageSet = (sets["USAGE"] = reactive({
-		id: "USAGE",
-		name: t("emote_menu.most_used_set"),
-		emotes: updateUsage(),
-	} as SevenTV.EmoteSet));
+	// const usageSet = (sets["USAGE"] = reactive({
+	// 	id: "USAGE",
+	// 	name: t("emote_menu.most_used_set"),
+	// 	emotes: updateUsage(),
+	// } as SevenTV.EmoteSet));
 
 	watch(favorites, () => {
 		favSet.emotes = updateFavorites();
 	});
 
-	watch([usage, shouldShowUsage], () => {
-		usageSet.emotes = updateUsage();
-	});
+	// watch([usage, shouldShowUsage], () => {
+	// 	usageSet.emotes = updateUsage();
+	// });
 }
 
 // Select an Emote Set to jump-scroll to

--- a/src/site/twitch.tv/modules/emote-menu/EmoteMenuTab.vue
+++ b/src/site/twitch.tv/modules/emote-menu/EmoteMenuTab.vue
@@ -8,7 +8,7 @@
 			</div>
 
 			<div class="emote-area">
-				<div v-for="es of sortedSets" :key="es.id" v-memo="[ctx.filter, es.emotes, selected]">
+				<div v-for="es of sortedSets" :key="es.id">
 					<EmoteMenuSet
 						:ref="'es-' + es.id"
 						:es="es"


### PR DESCRIPTION
Making some changes and fixes on performance issues

- [x] Remove use of `v-memo` (causes issues with unloading)
- [x] Disable Most Used Emotes temporarily ~~Refactor logic for most used emotes (currently performs extreme iteration)~~
- [x] Set a limit on the amount of items returned by colon-complete
- [x] Use async image decoding & native on-screen image loading

---

### Todo in a new PR

- [ ] Remove manual stagger in the Emote Menu
- [ ] Don't delay full-size load in tooltips when a cached version already exists
- [ ] Unify Emote Data Logic