### PR TITLE
fix: decimal no longer rendered as link

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,4 +1,6 @@
-### Version 3.0.6.1000
+### Untitled Version
+
+**The changes listed here are not assigned to an official release**.
 
 -   Links in chat messages now respect known TLDs instead of matching any url-like pattern
 

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,3 +1,7 @@
+### Version 3.0.6.1000
+
+-   Links in chat messages now respect known TLDs instead of matching any url-like pattern
+
 ### Version 3.0.5.1000
 
 -   Reply Threads should now appear properly and show all messages

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 		"script:compile-emoji": "tsc -p script/script.tsconfig.json --outDir dist/ && node dist/compile-emojis.js"
 	},
 	"dependencies": {
+		"tldts": "^6.0.3",
 		"vue": "^3.2.47"
 	},
 	"devDependencies": {

--- a/src/common/chat/Tokenizer.ts
+++ b/src/common/chat/Tokenizer.ts
@@ -8,6 +8,7 @@ import type {
 	VoidToken,
 } from "@/common/chat/ChatMessage";
 import { Regex } from "@/site/twitch.tv";
+import { parse } from "tldts";
 
 const URL_PROTOCOL_REGEXP = /^https?:\/\//i;
 
@@ -74,7 +75,7 @@ export class Tokenizer {
 			} else if (prevEmote && part.startsWith("ffz") && part.length > 3) {
 				// this is a temporary measure to hide ffz emote modifiers
 				tokens.push(toVoid(cursor, next - 1));
-			} else if (part.match(Regex.Link)) {
+			} else if (this.isValidLink(part)) {
 				// Check link
 				const actualURL = part.replace(URL_PROTOCOL_REGEXP, "");
 
@@ -113,6 +114,10 @@ export class Tokenizer {
 		tokens.sort((a, b) => a.range[0] - b.range[0]);
 
 		return (this.msg.tokens = tokens);
+	}
+
+	private isValidLink(message: string): boolean {
+		return parse(message).isIcann ?? false;
 	}
 }
 

--- a/src/common/chat/Tokenizer.ts
+++ b/src/common/chat/Tokenizer.ts
@@ -77,7 +77,11 @@ export class Tokenizer {
 			} else if (prevEmote && part.startsWith("ffz") && part.length > 3) {
 				// this is a temporary measure to hide ffz emote modifiers
 				tokens.push(toVoid(cursor, next - 1));
-			} else if (this.isValidLink(part, (url: URL) => {validUrl = url})) {
+			} else if (
+				this.isValidLink(part, (url: URL) => {
+					validUrl = url;
+				})
+			) {
 				tokens.push({
 					kind: "LINK",
 					range: [cursor + 1, next - 1],
@@ -115,16 +119,15 @@ export class Tokenizer {
 		return (this.msg.tokens = tokens);
 	}
 
-	private isValidLink(message: string, callBack: Function ): boolean {
+	private isValidLink(message: string, callBack: (url: URL) => void): boolean {
 		try {
 			const url = new URL(`https://${message.replace(URL_PROTOCOL_REGEXP, "")}`);
-			const {isIcann, domain} = parse(url.hostname);
+			const { isIcann, domain } = parse(url.hostname);
 
-			if(domain && isIcann) {
-				callBack(url)
+			if (domain && isIcann) {
+				callBack(url);
 				return true;
 			}
-
 		} catch (e) {
 			void 0;
 		}

--- a/src/common/chat/Tokenizer.ts
+++ b/src/common/chat/Tokenizer.ts
@@ -8,7 +8,7 @@ import type {
 	VoidToken,
 } from "@/common/chat/ChatMessage";
 import { Regex } from "@/site/twitch.tv";
-import { parse } from "tldts";
+import { parse as tldParse } from "tldts";
 
 const URL_PROTOCOL_REGEXP = /^https?:\/\//i;
 
@@ -122,7 +122,7 @@ export class Tokenizer {
 	private isValidLink(message: string, callBack: (url: URL) => void): boolean {
 		try {
 			const url = new URL(`https://${message.replace(URL_PROTOCOL_REGEXP, "")}`);
-			const { isIcann, domain } = parse(url.hostname);
+			const { isIcann, domain } = tldParse(url.hostname);
 
 			if (domain && isIcann) {
 				callBack(url);

--- a/src/site/twitch.tv/index.ts
+++ b/src/site/twitch.tv/index.ts
@@ -1,6 +1,5 @@
 export namespace Regex {
 	export const MessageDelimiter = new RegExp("( )", "g");
-	export const Link = new RegExp("^(?:https?:\\/\\/(?:www\\.)?)?([a-z0-9-]+\\.)+[a-z0-9@]{2,6}(\\/[^\\s]*)?$", "gim");
 	export const Mention = new RegExp("@([A-Za-z0-9_]{1,24})");
 	export const SevenTVLink = new RegExp("^https?:\\/\\/(?:www\\.)?7tv.app\\/emotes\\/(?<emoteID>[0-9a-f]{24})", "gi");
 }

--- a/src/site/twitch.tv/index.ts
+++ b/src/site/twitch.tv/index.ts
@@ -1,6 +1,6 @@
 export namespace Regex {
 	export const MessageDelimiter = new RegExp("( )", "g");
-	export const Link = new RegExp("^(?:https?:\\/\\/(?:www\\.)?)?([a-z0-9-]+\\.)+[a-z0-9@]{2,6}(\\/[^\\s]*)?$", "gim");
+	export const Link = new RegExp("^(?:https?:\\/\\/|www\\.)([a-z0-9-]+\\.)+[a-z0-9@]{2,6}(\\/[^\\s]*)?$", "gim");
 	export const Mention = new RegExp("@([A-Za-z0-9_]{1,24})");
 	export const SevenTVLink = new RegExp("^https?:\\/\\/(?:www\\.)?7tv.app\\/emotes\\/(?<emoteID>[0-9a-f]{24})", "gi");
 }

--- a/src/site/twitch.tv/index.ts
+++ b/src/site/twitch.tv/index.ts
@@ -1,6 +1,6 @@
 export namespace Regex {
 	export const MessageDelimiter = new RegExp("( )", "g");
-	export const Link = new RegExp("^(?:https?:\\/\\/|www\\.)([a-z0-9-]+\\.)+[a-z0-9@]{2,6}(\\/[^\\s]*)?$", "gim");
+	export const Link = new RegExp("^(?:https?:\\/\\/(?:www\\.)?)?([a-z0-9-]+\\.)+[a-z0-9@]{2,6}(\\/[^\\s]*)?$", "gim");
 	export const Mention = new RegExp("@([A-Za-z0-9_]{1,24})");
 	export const SevenTVLink = new RegExp("^https?:\\/\\/(?:www\\.)?7tv.app\\/emotes\\/(?<emoteID>[0-9a-f]{24})", "gi");
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3788,6 +3788,18 @@ throttle-debounce@^3.0.1:
   resolved "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-3.0.1.tgz"
   integrity sha512-dTEWWNu6JmeVXY0ZYoPuH5cRIwc0MeGbJwah9KUNYSJwommQpCzTySTpEe8Gs1J23aeWEuAobe4Ag7EHVt/LOg==
 
+tldts-core@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-6.0.3.tgz#b59d87507c51cd2488c322b92020b973b608b59a"
+  integrity sha512-PLiEM2aCkfGifyr8npbd93eWIW4isFRB44vTiup5DRie6e2Qy3+9quwHb252v12JyoM+RmF1cxtDgwD2PVBOjA==
+
+tldts@^6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/tldts/-/tldts-6.0.3.tgz#6a4a8bb550f396d6d72818606150e0e0263ae826"
+  integrity sha512-rcdUIwrcGuMWe5+fg5FFBrmWTYdbfpHwkk1AjBKoSDbpsdAsYqJYKoZOVOHn8MQCYatADKGAx/SU+jpSKxSYNw==
+  dependencies:
+    tldts-core "^6.0.3"
+
 to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz"


### PR DESCRIPTION
Closes #488

Changed the link regex to only match messages which starts with http, https or www. 
It won't be possible to write google.com in chat which was previously rendered as https://google.com

