### PR TITLE
fix: tab-complete chatters

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,3 +1,7 @@
+### Version 3.0.4.8000
+
+-   Fixed an issue which caused tab-completion to abruptly halt when a chatter's name is selected
+
 ### Version 3.0.4.7000
 
 -   Added hot-patching functionality to the extension

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+### Version 3.0.4
+
+-   Added hot-patching functionality to the extension
+-   Added chat rich embeds which allows twitch clips to preview in chat
+-   Added a "Copy Message" button
+-   Added an option to show thumbnail previews of streams when hovering over channels on the sidebar
+-   Temporarily disabled the "Most Used Emotes" feature, pending a refactor. This fixes severe input lag experienced by some users
+-   Made some internal changes which may decrease memory usage for some users
+-   Fixed bad performance on colon-completion by limiting the amount of items shown
+-   Fixed an issue which caused flickering when hovering on a deleted message
+-   Fixed a compatibility issue with another extension, causing distorted scrolling behavior in the settings menu
+
 ### Version 3.0.3
 
 -   Disabled YouTube support temporarily due an issue with request pattern

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Improve your viewing experience on Twitch & YouTube with new features, emotes, vanity and performance.",
 	"private": true,
 	"version": "3.0.4",
-	"dev_version": "7.0",
+	"dev_version": "8.0",
 	"scripts": {
 		"start": "NODE_ENV=dev yarn build:dev && NODE_ENV=dev vite --mode dev",
 		"build:section:app": "vite build --config vite.config.ts",

--- a/src/site/twitch.tv/modules/chat-input/ChatInput.vue
+++ b/src/site/twitch.tv/modules/chat-input/ChatInput.vue
@@ -147,7 +147,7 @@ function findMatchingTokens(str: string, mode: "tab" | "colon" = "tab", limit?: 
 			if (usedTokens.has(chatter.displayName) || !chatter.displayName.toLowerCase().startsWith(lPrefix)) continue;
 
 			matches.push({
-				token: (tokenStartsWithAt ? "@" : "") + chatter.displayName + " ",
+				token: (tokenStartsWithAt ? "@" : "") + chatter.displayName,
 				priority: 10,
 			});
 		}


### PR DESCRIPTION
Fixing an issue which causes tab-completion to break after a chater's name becomes the current token