### PR TITLE
fix bellow input emote refresh menu to toggle button

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -4,6 +4,7 @@
 
 -   Links in chat messages now respect known TLDs instead of matching any url-like pattern
 -   Added an option to show timeouts/bans directly in the chat without being a moderator
+-   Fixed the "Below input" setting, with which you can switch the menu by pressing the button
 
 ### Version 3.0.5.1000
 


### PR DESCRIPTION
Fixes #396

The issue was related to toggling the emoji menu button when setting the interface "Bellow input".

Settings option:

![image](https://user-images.githubusercontent.com/61266300/231546231-16c4c034-35c1-498a-9f61-e529949a572f.png)

How the menu was buggy before:

[screencast-www.twitch.tv-2023.04.12-21_04_53.webm](https://user-images.githubusercontent.com/61266300/231545965-fe0aaabe-213d-42e2-bd95-1f9a3c8753bf.webm)

How did it become:

[screencast-www.twitch.tv-2023.04.12-21_24_02.webm](https://user-images.githubusercontent.com/61266300/231551074-b7e9fddd-8691-4bfa-9bdb-e99d2ebb2cc8.webm)

