### PR TITLE
feat: add an option to highlight messages from moderators

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -4,6 +4,7 @@
 
 -   Links in chat messages now respect known TLDs instead of matching any url-like pattern
 -   Added an option to show timeouts/bans directly in the chat without being a moderator
+-   Added an option to highlight messages from moderators.
 
 ### Version 3.0.5.1000
 

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -4,6 +4,7 @@
 
 -   Added a tooltip to show the full message when hovering over replies in chat
 -   Fixed tooltips of nametag paints appearing even if they are disabled
+-   Added an option to highlight messages from moderators
 
 ### Version 3.0.6.1000
 
@@ -17,7 +18,6 @@
 -   Fixed an issue in the emote menu where the previously selected provider would close if a set was empty
 -   Fixed emote cards sometimes not showing who added the emote
 -   Fixed an issue where the detailed emote card would clip under existing chat messages
--   Added an option to highlight messages from moderators
 
 ### Version 3.0.5.1000
 

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -7,7 +7,7 @@
 -   Added options to change what emotes are displayed in the colon list and tab-completion carousel
 -   Fixed emote cards sometimes not showing who added the emote
 -   Fixed an issue where the detailed emote card would clip under existing chat messages
--   Added an option to highlight messages from moderators.
+-   Added an option to highlight messages from moderators
 
 ### Version 3.0.5.1000
 

--- a/src/site/twitch.tv/modules/chat/ChatList.vue
+++ b/src/site/twitch.tv/modules/chat/ChatList.vue
@@ -62,6 +62,7 @@ const pausedByVisibility = ref(false);
 const isModSliderEnabled = useConfig<boolean>("chat.mod_slider");
 const isAlternatingBackground = useConfig<boolean>("chat.alternating_background");
 const showMentionHighlights = useConfig("highlights.basic.mention");
+const showModeratorHighlights = useConfig<boolean>("highlights.basic.moderator");
 const showFirstTimeChatter = useConfig<boolean>("highlights.basic.first_time_chatter");
 const shouldPlaySoundOnMention = useConfig<boolean>("highlights.basic.mention_sound");
 const shouldFlashTitleOnHighlight = useConfig<boolean>("highlights.basic.mention_title_flash");
@@ -484,6 +485,24 @@ watch(
 		} else {
 			chatHighlights.remove("~mention");
 			chatHighlights.remove("~reply");
+		}
+	},
+	{
+		immediate: true,
+	},
+);
+
+watch(
+	[showModeratorHighlights],
+	([enabled]) => {
+		if (enabled) {
+			chatHighlights.define("~moderator", {
+				test: (msg) => "moderator" in msg.badges,
+				label: "Moderator",
+				color: "#00bb00",
+			});
+		} else {
+			chatHighlights.remove("~moderator");
 		}
 	},
 	{

--- a/src/site/twitch.tv/modules/chat/ChatModule.vue
+++ b/src/site/twitch.tv/modules/chat/ChatModule.vue
@@ -353,11 +353,11 @@ export const config = [
 		disabledIf: () => !useConfig("highlights.basic.mention").value,
 		defaultValue: true,
 	}),
-	declareConfig("highlights.basic.moderator", "TOGGLE", {
+	declareConfig<boolean>("highlights.basic.moderator", "TOGGLE", {
 		path: ["Highlights", "Built-In"],
 		label: "Show Moderator Highlights",
 		hint: "Whether or not to highlight messages from moderators",
-		defaultValue: true,
+		defaultValue: false,
 	}),
 	declareConfig<boolean>("highlights.basic.first_time_chatter", "TOGGLE", {
 		path: ["Highlights", "Built-In"],

--- a/src/site/twitch.tv/modules/chat/ChatModule.vue
+++ b/src/site/twitch.tv/modules/chat/ChatModule.vue
@@ -347,6 +347,12 @@ export const config = [
 		disabledIf: () => !useConfig("highlights.basic.mention").value,
 		defaultValue: true,
 	}),
+	declareConfig("highlights.basic.moderator", "TOGGLE", {
+		path: ["Highlights", "Built-In"],
+		label: "Show Moderator Highlights",
+		hint: "Whether or not to highlight messages from moderators",
+		defaultValue: true,
+	}),
 	declareConfig<boolean>("highlights.basic.first_time_chatter", "TOGGLE", {
 		path: ["Highlights", "Built-In"],
 		label: "Show First-Time Chatter Highlights",

--- a/src/site/twitch.tv/modules/chat/ChatModule.vue
+++ b/src/site/twitch.tv/modules/chat/ChatModule.vue
@@ -371,7 +371,7 @@ export const config = [
 		hint: "Whether or not to highlight users who are a restricted suspicious user",
 		defaultValue: true,
 	}),
-  declareConfig<boolean>("highlights.basic.moderator", "TOGGLE", {
+	declareConfig<boolean>("highlights.basic.moderator", "TOGGLE", {
 		path: ["Highlights", "Built-In"],
 		label: "Show Moderator Highlights",
 		hint: "Whether or not to highlight messages from moderators",


### PR DESCRIPTION
This adds an option to highlight messages from moderators.
The green (`#00bb00`) for highlights is the same color on the moderator badge.

This is reopen of #486.