### PR TITLE
Add option to show timeouts and bans directly in the chat

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -3,6 +3,7 @@
 **The changes listed here are not assigned to an official release**.
 
 -   Links in chat messages now respect known TLDs instead of matching any url-like pattern
+-   Added an option to show timeouts/bans directly in the chat without being a moderator
 
 ### Version 3.0.5.1000
 

--- a/src/site/twitch.tv/modules/chat/ChatList.vue
+++ b/src/site/twitch.tv/modules/chat/ChatList.vue
@@ -41,6 +41,7 @@ import { MessagePartType, MessageType, ModerationType } from "@/site/twitch.tv/"
 import ChatMessageUnhandled from "./ChatMessageUnhandled.vue";
 import UserMessage from "./components/message/UserMessage.vue";
 import ModSlider from "./components/mod/ModSlider.vue";
+import BasicSystemMessage from "./components/types/BasicSystemMessage.vue";
 
 const props = defineProps<{
 	list: HookedInstance<Twitch.ChatListComponent>;
@@ -60,6 +61,7 @@ const isHovering = toRef(properties, "hovering");
 const pausedByVisibility = ref(false);
 
 const isModSliderEnabled = useConfig<boolean>("chat.mod_slider");
+const showModerationMessages = useConfig<boolean>("chat.mod_messages");
 const isAlternatingBackground = useConfig<boolean>("chat.alternating_background");
 const showMentionHighlights = useConfig("highlights.basic.mention");
 const showFirstTimeChatter = useConfig<boolean>("highlights.basic.first_time_chatter");
@@ -356,6 +358,16 @@ function onModerationMessage(msgData: Twitch.ModerationMessage) {
 			nextTick(() => {
 				while (messages.moderated.length > 100) messages.moderated.pop();
 			});
+		}
+
+		// basic timeout/ban message in the chat
+		if (showModerationMessages.value && !properties.isModerator) {
+			const m = new ChatMessage().setComponent(BasicSystemMessage, {
+				text:
+					msgData.userLogin +
+					(msgData.duration > 0 ? ` was timed out (${msgData.duration}s)` : " was permanently banned"),
+			});
+			messages.add(m);
 		}
 	}
 }

--- a/src/site/twitch.tv/modules/chat/ChatModule.vue
+++ b/src/site/twitch.tv/modules/chat/ChatModule.vue
@@ -148,6 +148,12 @@ export const config = [
 		hint: "Enable the mod slider in channels where you are moderator",
 		defaultValue: true,
 	}),
+	declareConfig("chat.mod_messages", "TOGGLE", {
+		path: ["Chat", "Moderation"],
+		label: "Moderation Messages",
+		hint: "If enabled, you will see timeouts/bans in the chat even if you are not a moderator",
+		defaultValue: false,
+	}),
 	declareConfig("chat.ignore_clear_chat", "TOGGLE", {
 		path: ["Chat", "Moderation"],
 		label: "Ignore Clear Chat",


### PR DESCRIPTION
Adds an opt-in option to see basic timeout and ban messages directly in the chat without the need of mod logs