### PR TITLE
Added issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,49 @@
+name: 🐛 Bug Report
+description: File a bug report
+title: "[BUG] <title>"
+labels: bug
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please [search here](https://github.com/SevenTV/Extension/issues) to see if an issue already exists for your problem.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: checkboxes
+    attributes:
+      label: This issue exists in the latest nightly version
+      description: Please make sure you have installed the latest nightly version and verified it is still an issue.
+      options:
+        - label: I am using the latest nightly version
+          required: true
+  - type: dropdown
+    attributes:
+      label: What browsers are you seeing the problem on?
+      multiple: true
+      options:
+        - Chrome
+        - Firefox
+        - Opera
+        - Microsoft Edge
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Current Behavior
+      description: A clear & concise description of what you're experiencing.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: A clear & concise description of what you expected to happen.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps To Reproduce
+      description: Steps to reproduce the behavior.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: 📄 Feature Request
+description: File a feature request
+title: "[REQUEST] <title>"
+labels: enhancement
+body:
+  - type: checkboxes
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please [search here](https://github.com/SevenTV/Extension/issues) to see if an issue already exists for your feature.
+      options:
+        - label: I have searched the existing issues
+          required: true
+  - type: checkboxes
+    attributes:
+      label: This feature does not exist in the latest nightly version
+      description: Please make sure you have installed the latest nightly version and verified it is not a feature already.
+      options:
+        - label: I have checked the latest nightly version
+          required: true
+  - type: textarea
+    attributes:
+      label: Feature Description
+      description: A clear & concise description of what you're requesting.
+    validations:
+      required: true


### PR DESCRIPTION
Adds GitHub issue forms to the repository, reading issues currently is a mess.

[GitHub issue forms docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository)