### PR TITLE
fix switch focus to search bar after opening emote menu from bellow input mode(#436)

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -4,6 +4,7 @@
 
 -   Links in chat messages now respect known TLDs instead of matching any url-like pattern
 -   Added an option to show timeouts/bans directly in the chat without being a moderator
+-   Fixed switch focus to search bar after opening emote menu from "bellow input" mode
 
 ### Version 3.0.5.1000
 

--- a/src/site/twitch.tv/modules/emote-menu/EmoteMenu.vue
+++ b/src/site/twitch.tv/modules/emote-menu/EmoteMenu.vue
@@ -120,7 +120,10 @@ onMounted(() => {
 		"emote-menu",
 		EmoteMenuButton,
 		{
-			onClick: () => (ctx.open = !ctx.open),
+			onClick: () => {
+				ctx.open = !ctx.open;
+				onFocusSearchEmoteInput();
+			},
 		},
 		1,
 	);
@@ -134,6 +137,14 @@ onKeyStroke("e", (ev) => {
 	toggle();
 	ev.preventDefault();
 });
+
+function onFocusSearchEmoteInput() {
+	nextTick(() => {
+		if (!searchInputRef.value) return;
+
+		searchInputRef.value.focus();
+	});
+}
 
 // Toggle the menu's visibility
 function toggle(native?: boolean) {
@@ -154,11 +165,7 @@ function toggle(native?: boolean) {
 	}
 
 	ctx.open = !ctx.open;
-	nextTick(() => {
-		if (!searchInputRef.value) return;
-
-		searchInputRef.value.focus();
-	});
+	onFocusSearchEmoteInput();
 }
 
 function handleEmoteUsage(s: string): string {


### PR DESCRIPTION
fix #436

With work in emote menu for "below input mode"  lost focus to input. Fixed it.

Before it:

[screencast-translate.yandex.ru-2023.04.14-16_13_10.webm](https://user-images.githubusercontent.com/61266300/232053628-b9cb334e-3a99-4940-8d55-b3b8ec5f4bb3.webm)

After it:

[screencast-extensions-2023.04.14-16_17_15.webm](https://user-images.githubusercontent.com/61266300/232054515-e3a04a17-0856-46d3-a4df-a0b5358d91f6.webm)
