### PR TITLE
Add option to highlight your own messages

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -3,6 +3,7 @@
 **The changes listed here are not assigned to an official release**.
 
 -   Links in chat messages now respect known TLDs instead of matching any url-like pattern
+-   Added a option to highlight your own chat messages
 
 ### Version 3.0.5.1000
 

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -4,7 +4,13 @@
 
 -   Links in chat messages now respect known TLDs instead of matching any url-like pattern
 -   Added an option to show timeouts/bans directly in the chat without being a moderator
--   Added a option to highlight your own chat messages
+-   Added options to change what emotes are displayed in the colon list and tab-completion carousel
+-   Fixed an issue in the emote menu where the previously selected provider would close if a set was empty
+-   Fixed emote cards sometimes not showing who added the emote
+-   Fixed an issue where the detailed emote card would clip under existing chat messages
+-   Added an option to hide monitored suspicious user highlights
+-   Added an option to hide restricted suspicious user highlights
+-   Added an option to highlight your own chat messages
 
 ### Version 3.0.5.1000
 

--- a/src/site/twitch.tv/modules/chat/ChatList.vue
+++ b/src/site/twitch.tv/modules/chat/ChatList.vue
@@ -63,6 +63,7 @@ const isModSliderEnabled = useConfig<boolean>("chat.mod_slider");
 const isAlternatingBackground = useConfig<boolean>("chat.alternating_background");
 const showMentionHighlights = useConfig("highlights.basic.mention");
 const showFirstTimeChatter = useConfig<boolean>("highlights.basic.first_time_chatter");
+const showYouHighlights = useConfig<boolean>("highlights.basic.you");
 const shouldPlaySoundOnMention = useConfig<boolean>("highlights.basic.mention_sound");
 const shouldFlashTitleOnHighlight = useConfig<boolean>("highlights.basic.mention_title_flash");
 
@@ -194,6 +195,11 @@ function onChatMessage(msg: ChatMessage, msgData: Twitch.AnyMessage, shouldRende
 			msg.setHighlight("#c832c8", "First Message");
 		} else if (msgData.isReturningChatter) {
 			msg.setHighlight("#3296e6", "Returning Chatter");
+		}
+
+		// Assign highlight to your own message
+		if (msgData.nonce && showYouHighlights.value) {
+			msg.setHighlight("#3ad3e0", "You");
 		}
 
 		// assign parent message data

--- a/src/site/twitch.tv/modules/chat/ChatList.vue
+++ b/src/site/twitch.tv/modules/chat/ChatList.vue
@@ -65,7 +65,7 @@ const showModerationMessages = useConfig<boolean>("chat.mod_messages");
 const isAlternatingBackground = useConfig<boolean>("chat.alternating_background");
 const showMentionHighlights = useConfig("highlights.basic.mention");
 const showFirstTimeChatter = useConfig<boolean>("highlights.basic.first_time_chatter");
-const showYouHighlights = useConfig<boolean>("highlights.basic.you");
+const showSelfHighlights = useConfig<boolean>("highlights.basic.self");
 const shouldPlaySoundOnMention = useConfig<boolean>("highlights.basic.mention_sound");
 const shouldFlashTitleOnHighlight = useConfig<boolean>("highlights.basic.mention_title_flash");
 
@@ -197,11 +197,6 @@ function onChatMessage(msg: ChatMessage, msgData: Twitch.AnyMessage, shouldRende
 			msg.setHighlight("#c832c8", "First Message");
 		} else if (msgData.isReturningChatter) {
 			msg.setHighlight("#3296e6", "Returning Chatter");
-		}
-
-		// Assign highlight to your own message
-		if (msgData.nonce && showYouHighlights.value) {
-			msg.setHighlight("#3ad3e0", "You");
 		}
 
 		// assign parent message data
@@ -455,6 +450,25 @@ watch([alt, isHovering], ([isAlt, isHover]) => {
 		pausedByHotkey = false;
 	}
 });
+
+// Assign highlight to your own message
+watch(
+	[identity, showSelfHighlights],
+	([identity, enabled]) => {
+		if (enabled) {
+			chatHighlights.define("~self", {
+				test: (msg) => msg.author?.id === identity?.id,
+				label: "You",
+				color: "#3ad3e0",
+			});
+		} else {
+			chatHighlights.remove("~self");
+		}
+	},
+	{
+		immediate: true,
+	},
+);
 
 // Pause scrolling when page is not visible
 watch(pageVisibility, (state) => {

--- a/src/site/twitch.tv/modules/chat/ChatList.vue
+++ b/src/site/twitch.tv/modules/chat/ChatList.vue
@@ -456,9 +456,9 @@ watch([alt, isHovering], ([isAlt, isHover]) => {
 watch(
 	[identity, showSelfHighlights],
 	([identity, enabled]) => {
-		if (enabled) {
+		if (enabled && identity) {
 			chatHighlights.define("~self", {
-				test: (msg) => msg.author?.id === identity?.id,
+				test: (msg) => !!(msg.author && identity) && msg.author.id === identity.id,
 				label: "You",
 				color: "#3ad3e0",
 			});

--- a/src/site/twitch.tv/modules/chat/ChatModule.vue
+++ b/src/site/twitch.tv/modules/chat/ChatModule.vue
@@ -359,10 +359,10 @@ export const config = [
 		hint: "Whether or not to highlight users who are chatting for the first time",
 		defaultValue: true,
 	}),
-	declareConfig<boolean>("highlights.basic.you", "TOGGLE", {
+	declareConfig<boolean>("highlights.basic.self", "TOGGLE", {
 		path: ["Highlights", "Built-In"],
 		label: "Show Highlights for Your Own Messages",
-		hint: "Whether or not to highlight messages sent by you",
+		hint: "Whether or not to highlight messages sent by yourself",
 		defaultValue: false,
 	}),
 	declareConfig<Map<string, HighlightDef>>("highlights.custom", "CUSTOM", {

--- a/src/site/twitch.tv/modules/chat/ChatModule.vue
+++ b/src/site/twitch.tv/modules/chat/ChatModule.vue
@@ -353,6 +353,12 @@ export const config = [
 		hint: "Whether or not to highlight users who are chatting for the first time",
 		defaultValue: true,
 	}),
+	declareConfig<boolean>("highlights.basic.you", "TOGGLE", {
+		path: ["Highlights", "Built-In"],
+		label: "Show Highlights for Your Own Messages",
+		hint: "Whether or not to highlight messages sent by you",
+		defaultValue: false,
+	}),
 	declareConfig<Map<string, HighlightDef>>("highlights.custom", "CUSTOM", {
 		path: ["Highlights", ""],
 		custom: {


### PR DESCRIPTION
Adds a option in highlights/built-in to highlight your own chat messages.

Setting option:
![image](https://user-images.githubusercontent.com/76515905/232574259-d78992a8-03e9-43ec-90ed-304ac2070da1.png)

Highlight image:
![image](https://user-images.githubusercontent.com/76515905/232075901-add1224d-3dfc-4cd1-8297-d71f1f147362.png)

Closes #470 