### PR TITLE
fix: displayName mentions

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -4,6 +4,7 @@
 
 -   Links in chat messages now respect known TLDs instead of matching any url-like pattern
 -   Added an option to show timeouts/bans directly in the chat without being a moderator
+-   Fixed mentions using the display name, not the international name
 
 ### Version 3.0.5.1000
 

--- a/src/site/twitch.tv/index.ts
+++ b/src/site/twitch.tv/index.ts
@@ -1,6 +1,6 @@
 export namespace Regex {
 	export const MessageDelimiter = new RegExp("( )", "g");
-	export const Mention = new RegExp("@([A-Za-z0-9_]{1,24})");
+	export const Mention = new RegExp("@\\S*");
 	export const SevenTVLink = new RegExp("^https?:\\/\\/(?:www\\.)?7tv.app\\/emotes\\/(?<emoteID>[0-9a-f]{24})", "gi");
 }
 

--- a/src/site/twitch.tv/modules/chat/ChatList.vue
+++ b/src/site/twitch.tv/modules/chat/ChatList.vue
@@ -464,10 +464,15 @@ watch(pageVisibility, (state) => {
 watch(
 	[identity, showMentionHighlights, shouldPlaySoundOnMention, shouldFlashTitleOnHighlight],
 	([identity, enabled, sound, flash]) => {
-		const rxs = identity ? `\\b${identity.username}\\b` : null;
-		if (!rxs) return;
+		if (!identity) return;
 
-		const rx = new RegExp(rxs, "i");
+		// Handle both username and displayName mentions
+		// Workaround \b not working properly with unicode characters
+		const hasMultiLangName = "displayName" in identity && identity.username !== identity.displayName.toLowerCase();
+		const rxs = hasMultiLangName
+			? `((?<=^|\\P{L})${identity.username}|${identity.displayName}(?=\\P{L}|$))`
+			: `\\b${identity.username}\\b`;
+		const rx = new RegExp(rxs, hasMultiLangName ? "iu" : "i");
 
 		if (enabled) {
 			chatHighlights.define("~mention", {


### PR DESCRIPTION
This adds/fixes support for mentions using the displayName rather than the user's international username

JavaScript RegExp does not support unicode `\b` or `(*UCP)` so I had to use this ugly workaround, which is used only if the user has different display name than username. I am not sure if there is any better solution than this. [Lookbehind support](https://caniuse.com/js-regexp-lookbehind) should be fine considering 7TV does not have a Safari extension
I also changed the mention regex to `@\S*` otherwise unicode mentions are not matched

Fixes #471 