### PR TITLE
colon-completion list and tab-completion carousel mode options

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -4,6 +4,7 @@
 
 -   Links in chat messages now respect known TLDs instead of matching any url-like pattern
 -   Added an option to show timeouts/bans directly in the chat without being a moderator
+-   Added options to change what emotes are displayed in the colon list and tab-completion carousel
 
 ### Version 3.0.5.1000
 

--- a/src/site/twitch.tv/modules/chat-input/ChatInput.vue
+++ b/src/site/twitch.tv/modules/chat-input/ChatInput.vue
@@ -57,6 +57,8 @@ const shouldColonCompleteEmoji = useConfig("chat_input.autocomplete.colon.emoji"
 const shouldAutocompleteChatters = useConfig("chat_input.autocomplete.chatters");
 const shouldRenderAutocompleteCarousel = useConfig("chat_input.autocomplete.carousel");
 const mayUseControlEnter = useConfig("chat_input.spam.rapid_fire_send");
+const colonCompletionMode = useConfig<number>("chat_input.autocomplete.colon.mode");
+const tabCompletionMode = useConfig<number>("chat_input.autocomplete.carousel.mode");
 
 const providers = ref<Record<string, Twitch.ChatAutocompleteProvider>>({});
 
@@ -89,12 +91,17 @@ function findMatchingTokens(str: string, mode: "tab" | "colon" = "tab", limit?: 
 
 	const matches: TabToken[] = [];
 
+	// Test modes
+	// 0: startsWith
+	// 1: includes
+	const testMode = mode === "tab" ? tabCompletionMode.value : colonCompletionMode.value;
+
 	const prefix = str.toLowerCase();
 	const test = (token: string) =>
 		({
-			tab: token.toLowerCase().startsWith(prefix),
-			colon: token.toLowerCase().includes(prefix),
-		}[mode]);
+			0: token.toLowerCase().startsWith(prefix),
+			1: token.toLowerCase().includes(prefix),
+		}[testMode]);
 
 	for (const [token, ae] of Object.entries(cosmetics.emotes)) {
 		if (usedTokens.has(token) || !test(token)) continue;

--- a/src/site/twitch.tv/modules/chat-input/ChatInputModule.vue
+++ b/src/site/twitch.tv/modules/chat-input/ChatInputModule.vue
@@ -143,6 +143,17 @@ export const config = [
 		hint: "Whether or not to also include emojis in the colon-completion list (This may impact performance)",
 		defaultValue: false,
 	}),
+	declareConfig("chat_input.autocomplete.colon.mode", "DROPDOWN", {
+		path: ["Chat", "Autocompletion"],
+		label: "Colon-completion: Mode",
+		disabledIf: () => !useConfig("chat_input.autocomplete.colon").value,
+		hint: "What emotes should be displayed in the colon-completion list",
+		options: [
+			["Must start with input", 0],
+			["Must include input", 1],
+		],
+		defaultValue: 1,
+	}),
 	declareConfig("chat_input.autocomplete.carousel", "TOGGLE", {
 		path: ["Chat", "Autocompletion"],
 		label: "Tab-completion Carousel",
@@ -155,6 +166,17 @@ export const config = [
 		disabledIf: () => !useConfig("chat_input.autocomplete.carousel").value,
 		hint: "Whether or not to allow using left/right arrow keys to navigate the tab-completion carousel",
 		defaultValue: true,
+	}),
+	declareConfig("chat_input.autocomplete.carousel.mode", "DROPDOWN", {
+		path: ["Chat", "Autocompletion"],
+		label: "Tab-completion: Mode",
+		disabledIf: () => !useConfig("chat_input.autocomplete.carousel").value,
+		hint: "What emotes should be displayed in the tab-completion carousel",
+		options: [
+			["Must start with input", 0],
+			["Must include input", 1],
+		],
+		defaultValue: 0,
 	}),
 	declareConfig("chat_input.autocomplete.chatters", "TOGGLE", {
 		path: ["Chat", "Autocompletion"],


### PR DESCRIPTION
Allow the user to select if they want to filter emotes by `starstWith` or `includes` in colon-completion list and tab-completion carousel for each independently, defaults stay the same