### PR TITLE
Added new chat autocompletion setting option. Double click on the mes…

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -4,7 +4,7 @@
 
 -   Links in chat messages now respect known TLDs instead of matching any url-like pattern
 -   Added an option to show timeouts/bans directly in the chat without being a moderator
--   Added new chat autocompletion setting option. Double click on the message author
+-   Added new chat autocompletion setting option. Quickly add a nickname to a message
 
 ### Version 3.0.5.1000
 

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -4,6 +4,7 @@
 
 -   Links in chat messages now respect known TLDs instead of matching any url-like pattern
 -   Added an option to show timeouts/bans directly in the chat without being a moderator
+-   Added new chat autocompletion setting option. Double click on the message author
 
 ### Version 3.0.5.1000
 

--- a/src/site/twitch.tv/modules/chat-input/ChatInputModule.vue
+++ b/src/site/twitch.tv/modules/chat-input/ChatInputModule.vue
@@ -162,11 +162,15 @@ export const config = [
 		hint: "Whether or not to consider the usernames of active chatters when using tab-completion",
 		defaultValue: true,
 	}),
-	declareConfig("chat_input.autocomplete.author_doubleClick", "TOGGLE", {
+	declareConfig("chat_input.autocomplete.author_quick_pick", "DROPDOWN", {
 		path: ["Chat", "Autocompletion"],
-		label: "Double click on the message author",
-		hint: "When you double-click on the message author in a chat, their nickname is added to send a personal message",
-		defaultValue: false,
+		label: "Quickly add a nickname to a message",
+		hint: "An option that allows you to quickly add the nickname of the author of the message in the chat in the message input field",
+		options: [
+			["Right click", 0],
+			["Left double click", 1],
+		],
+		defaultValue: 0,
 	}),
 	declareConfig("chat_input.spam.bypass_duplicate", "TOGGLE", {
 		path: ["Chat", "Typing"],

--- a/src/site/twitch.tv/modules/chat-input/ChatInputModule.vue
+++ b/src/site/twitch.tv/modules/chat-input/ChatInputModule.vue
@@ -162,6 +162,12 @@ export const config = [
 		hint: "Whether or not to consider the usernames of active chatters when using tab-completion",
 		defaultValue: true,
 	}),
+	declareConfig("chat_input.autocomplete.author_doubleClick", "TOGGLE", {
+		path: ["Chat", "Autocompletion"],
+		label: "Double click on the message author",
+		hint: "When you double-click on the message author in a chat, their nickname is added to send a personal message",
+		defaultValue: false,
+	}),
 	declareConfig("chat_input.spam.bypass_duplicate", "TOGGLE", {
 		path: ["Chat", "Typing"],
 		label: "Bypass Duplicate Message Check",

--- a/src/site/twitch.tv/modules/chat/ChatController.vue
+++ b/src/site/twitch.tv/modules/chat/ChatController.vue
@@ -108,7 +108,10 @@ const handlerAuthorQuickPickNameClick = (username: ChatUser["username"]) => {
 		// // React component's context might be lost if we switched to another stream,
 		// if "ChatInputController" doesn't load in time, I handle this script.
 		try {
-			autocompleteInputRef.value.setValue(`${autocompleteInputRef.value.getValue()} @${username}`);
+			const currentInputValue = autocompleteInputRef.value.getValue();
+			const authorPickTemplate = `@${username},`;
+
+			autocompleteInputRef.value.setValue(`${currentInputValue} ${authorPickTemplate} `);
 			autocompleteInputRef.value.componentRef.focus();
 		} catch (e) {
 			const error = e as Error;

--- a/src/site/twitch.tv/modules/chat/ChatList.vue
+++ b/src/site/twitch.tv/modules/chat/ChatList.vue
@@ -7,7 +7,12 @@
 					v-bind="{ msg }"
 				>
 					<component :is="msg.instance" v-bind="msg.componentProps" :msg="msg">
-						<UserMessage :msg="msg" :emotes="emotes.active" :chatters="messages.chattersByUsername" />
+						<UserMessage
+							:msg="msg"
+							:emotes="emotes.active"
+							:chatters="messages.chattersByUsername"
+							@name-double-click="(event) => emit('nameDoubleClick', event)"
+						/>
 					</component>
 				</component>
 			</template>
@@ -46,6 +51,10 @@ import BasicSystemMessage from "./components/types/BasicSystemMessage.vue";
 const props = defineProps<{
 	list: HookedInstance<Twitch.ChatListComponent>;
 	messageHandler: Twitch.MessageHandlerAPI | null;
+}>();
+
+const emit = defineEmits<{
+	(event: "nameDoubleClick", e: ChatUser["username"]): void;
 }>();
 
 const ctx = useChannelContext();

--- a/src/site/twitch.tv/modules/chat/ChatList.vue
+++ b/src/site/twitch.tv/modules/chat/ChatList.vue
@@ -11,7 +11,7 @@
 							:msg="msg"
 							:emotes="emotes.active"
 							:chatters="messages.chattersByUsername"
-							@name-double-click="(event) => emit('nameDoubleClick', event)"
+							@author-quick-pick-name-click="(event) => emit('authorQuickPickNameClick', event)"
 						/>
 					</component>
 				</component>
@@ -54,7 +54,7 @@ const props = defineProps<{
 }>();
 
 const emit = defineEmits<{
-	(event: "nameDoubleClick", e: ChatUser["username"]): void;
+	(event: "authorQuickPickNameClick", e: ChatUser["username"]): void;
 }>();
 
 const ctx = useChannelContext();

--- a/src/site/twitch.tv/modules/chat/components/message/UserMessage.vue
+++ b/src/site/twitch.tv/modules/chat/components/message/UserMessage.vue
@@ -41,7 +41,7 @@
 			:badges="msg.badges"
 			:msg-id="msg.sym"
 			@name-click="(ev) => openViewerCard(ev, msg.author!.username, msg.id)"
-			@name-double-click="emit('nameDoubleClick', msg.author!.username)"
+			@author-quick-pick-name-click="emit('authorQuickPickNameClick', msg.author!.username)"
 			@badge-click="(ev) => openViewerCard(ev, msg.author!.username,msg.id)"
 		/>
 
@@ -131,7 +131,7 @@ const props = withDefaults(
 );
 
 const emit = defineEmits<{
-	(event: "nameDoubleClick", e: ChatUser["username"]): void;
+	(event: "authorQuickPickNameClick", e: ChatUser["username"]): void;
 }>();
 
 const msg = toRef(props, "msg");

--- a/src/site/twitch.tv/modules/chat/components/message/UserMessage.vue
+++ b/src/site/twitch.tv/modules/chat/components/message/UserMessage.vue
@@ -41,7 +41,8 @@
 			:badges="msg.badges"
 			:msg-id="msg.sym"
 			@name-click="(ev) => openViewerCard(ev, msg.author!.username, msg.id)"
-			@badge-click="(ev) => openViewerCard(ev, msg.author!.username, msg.id)"
+			@name-double-click="emit('nameDoubleClick', msg.author!.username)"
+			@badge-click="(ev) => openViewerCard(ev, msg.author!.username,msg.id)"
 		/>
 
 		<span v-if="!hideAuthor">
@@ -128,6 +129,10 @@ const props = withDefaults(
 	}>(),
 	{ as: "Chat" },
 );
+
+const emit = defineEmits<{
+	(event: "nameDoubleClick", e: ChatUser["username"]): void;
+}>();
 
 const msg = toRef(props, "msg");
 const msgEl = ref<HTMLSpanElement | null>();

--- a/src/site/twitch.tv/modules/chat/components/message/UserTag.vue
+++ b/src/site/twitch.tv/modules/chat/components/message/UserTag.vue
@@ -18,7 +18,8 @@
 			v-tooltip="paint && paint.data ? `Paint: ${paint.data.name}` : ''"
 			class="seventv-chat-user-username"
 			@click="(e) => emit('nameClick', e)"
-			@dblclick="authorDoubleClickHandler"
+			@dblclick="(event) => authorQuickPickClickHandler(1, event)"
+			@click.right="(event) => authorQuickPickClickHandler(0, event)"
 		>
 			<span v-cosmetic-paint="paint ? paint.id : null">
 				<span v-if="asMention">@</span>
@@ -48,22 +49,25 @@ const props = defineProps<{
 
 const emit = defineEmits<{
 	(event: "nameClick", e: MouseEvent): void;
-	(event: "nameDoubleClick", e: MouseEvent): void;
+	(event: "authorQuickPickNameClick"): void;
 	(event: "badgeClick", e: MouseEvent, badge: Twitch.ChatBadge): void;
 }>();
 
 const ctx = useChannelContext();
 const properties = useChatProperties(ctx);
 const cosmetics = useCosmetics(props.user.id);
-const isAuthorDoubleClick = useConfig<true | false>("chat_input.autocomplete.author_doubleClick");
+const authorQuickPickValue = useConfig<0 | 1>("chat_input.autocomplete.author_quick_pick");
 
 const twitchBadges = ref([] as Twitch.ChatBadge[]);
 
 const paint = ref<SevenTV.Cosmetic<"PAINT"> | null>(null);
 const activeBadges = ref<SevenTV.Cosmetic<"BADGE">[]>([]);
 
-const authorDoubleClickHandler = (event: MouseEvent) => {
-	if (isAuthorDoubleClick.value) emit("nameDoubleClick", event);
+const authorQuickPickClickHandler = (eventType: 0 | 1, event: MouseEvent) => {
+	if (authorQuickPickValue.value === eventType) {
+		event.preventDefault();
+		emit("authorQuickPickNameClick");
+	}
 };
 
 if (props.badges && properties.twitchBadgeSets) {

--- a/src/site/twitch.tv/modules/chat/components/message/UserTag.vue
+++ b/src/site/twitch.tv/modules/chat/components/message/UserTag.vue
@@ -18,6 +18,7 @@
 			v-tooltip="paint && paint.data ? `Paint: ${paint.data.name}` : ''"
 			class="seventv-chat-user-username"
 			@click="(e) => emit('nameClick', e)"
+			@dblclick="authorDoubleClickHandler"
 		>
 			<span v-cosmetic-paint="paint ? paint.id : null">
 				<span v-if="asMention">@</span>
@@ -34,6 +35,7 @@ import type { ChatUser } from "@/common/chat/ChatMessage";
 import { useChannelContext } from "@/composable/channel/useChannelContext";
 import { useChatProperties } from "@/composable/chat/useChatProperties";
 import { useCosmetics } from "@/composable/useCosmetics";
+import { useConfig } from "@/composable/useSettings";
 import Badge from "./Badge.vue";
 
 const props = defineProps<{
@@ -46,16 +48,23 @@ const props = defineProps<{
 
 const emit = defineEmits<{
 	(event: "nameClick", e: MouseEvent): void;
+	(event: "nameDoubleClick", e: MouseEvent): void;
 	(event: "badgeClick", e: MouseEvent, badge: Twitch.ChatBadge): void;
 }>();
 
 const ctx = useChannelContext();
 const properties = useChatProperties(ctx);
 const cosmetics = useCosmetics(props.user.id);
+const isAuthorDoubleClick = useConfig<true | false>("chat_input.autocomplete.author_doubleClick");
+
 const twitchBadges = ref([] as Twitch.ChatBadge[]);
 
 const paint = ref<SevenTV.Cosmetic<"PAINT"> | null>(null);
 const activeBadges = ref<SevenTV.Cosmetic<"BADGE">[]>([]);
+
+const authorDoubleClickHandler = (event: MouseEvent) => {
+	if (isAuthorDoubleClick.value) emit("nameDoubleClick", event);
+};
 
 if (props.badges && properties.twitchBadgeSets) {
 	for (const [key, value] of Object.entries(props.badges)) {


### PR DESCRIPTION
 Added new chat autocompletion setting option. Double click on the message author(#387)
 
 As it was before adding the feature:

[screencast-www.twitch.tv-2023.04.16-18_00_23.webm](https://user-images.githubusercontent.com/61266300/232321755-f2713de3-6713-49b5-a33e-6e47cb367710.webm)

When double-clicking on the nickname of the author of the message in the input text of the message, the nickname did not appear, which can be referred to in a future message.

What's added with the new feature:

- New setting in chat autocompletion options "Double click on the message author". Disabled by default.

![image](https://user-images.githubusercontent.com/61266300/232321910-e4e6e0cb-5a09-41a2-ae68-afa650a9189b.png)

- If the setting is enabled, now when you double-click on the nickname of the author of the message, his nickname will be added to the message input field:

[screencast-www.twitch.tv-2023.04.16-18_12_31.webm](https://user-images.githubusercontent.com/61266300/232322422-3d9108c8-faf5-4290-806a-939b1c2e406e.webm)

I also checked the feature after transitions between different twitch streamers.

