### PR TITLE
feat: add option to toggle hiding emote modifiers

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -7,6 +7,7 @@
 -   Added options to change what emotes are displayed in the colon list and tab-completion carousel
 -   Fixed emote cards sometimes not showing who added the emote
 -   Fixed an issue where the detailed emote card would clip under existing chat messages
+-   Added an option to toggle the hiding of BTTV and FFZ emote modifiers
 
 ### Version 3.0.5.1000
 

--- a/src/common/chat/Tokenizer.ts
+++ b/src/common/chat/Tokenizer.ts
@@ -23,7 +23,7 @@ export class Tokenizer {
 
 		const textParts = this.msg.body.split(" ");
 		const getEmote = (name: string) => opt.localEmoteMap?.[name] ?? opt.emoteMap[name];
-		const showModifiers = opt.showModifiers ?? true;
+		const showModifiers = opt.showModifiers;
 
 		let cursor = -1;
 		let lastEmoteToken: EmoteToken | undefined = undefined;

--- a/src/common/chat/Tokenizer.ts
+++ b/src/common/chat/Tokenizer.ts
@@ -23,7 +23,7 @@ export class Tokenizer {
 
 		const textParts = this.msg.body.split(" ");
 		const getEmote = (name: string) => opt.localEmoteMap?.[name] ?? opt.emoteMap[name];
-		const hideModifiers = opt.hideModifiers ?? true;
+		const showModifiers = opt.showModifiers ?? true;
 
 		let cursor = -1;
 		let lastEmoteToken: EmoteToken | undefined = undefined;
@@ -71,10 +71,10 @@ export class Tokenizer {
 						}),
 					);
 				}
-			} else if (hideModifiers && nextEmote && backwardModifierBlacklist.has(part)) {
+			} else if (!showModifiers && nextEmote && backwardModifierBlacklist.has(part)) {
 				// this is a temporary measure to hide bttv emote modifiers
 				tokens.push(toVoid(cursor, next - 1));
-			} else if (hideModifiers && prevEmote && part.startsWith("ffz") && part.length > 3) {
+			} else if (!showModifiers && prevEmote && part.startsWith("ffz") && part.length > 3) {
 				// this is a temporary measure to hide ffz emote modifiers
 				tokens.push(toVoid(cursor, next - 1));
 			} else if ((parsedUrl = this.isValidLink(part))) {
@@ -137,5 +137,5 @@ export interface TokenizeOptions {
 	localEmoteMap?: Record<string, SevenTV.ActiveEmote>;
 	filteredWords?: string[];
 	actorUsername?: string;
-	hideModifiers?: boolean;
+	showModifiers?: boolean;
 }

--- a/src/common/chat/Tokenizer.ts
+++ b/src/common/chat/Tokenizer.ts
@@ -23,6 +23,7 @@ export class Tokenizer {
 
 		const textParts = this.msg.body.split(" ");
 		const getEmote = (name: string) => opt.localEmoteMap?.[name] ?? opt.emoteMap[name];
+		const hideModifiers = opt.hideModifiers ?? true;
 
 		let cursor = -1;
 		let lastEmoteToken: EmoteToken | undefined = undefined;
@@ -70,10 +71,10 @@ export class Tokenizer {
 						}),
 					);
 				}
-			} else if (nextEmote && backwardModifierBlacklist.has(part)) {
+			} else if (hideModifiers && nextEmote && backwardModifierBlacklist.has(part)) {
 				// this is a temporary measure to hide bttv emote modifiers
 				tokens.push(toVoid(cursor, next - 1));
-			} else if (prevEmote && part.startsWith("ffz") && part.length > 3) {
+			} else if (hideModifiers && prevEmote && part.startsWith("ffz") && part.length > 3) {
 				// this is a temporary measure to hide ffz emote modifiers
 				tokens.push(toVoid(cursor, next - 1));
 			} else if ((parsedUrl = this.isValidLink(part))) {
@@ -136,4 +137,5 @@ export interface TokenizeOptions {
 	localEmoteMap?: Record<string, SevenTV.ActiveEmote>;
 	filteredWords?: string[];
 	actorUsername?: string;
+	hideModifiers?: boolean;
 }

--- a/src/site/twitch.tv/modules/chat/ChatModule.vue
+++ b/src/site/twitch.tv/modules/chat/ChatModule.vue
@@ -145,7 +145,7 @@ export const config = [
 	declareConfig("chat.show_emote_modifiers", "TOGGLE", {
 		path: ["Chat", "Style"],
 		label: "Show Emote Modifiers",
-		hint: "Show BTTV and FFZ emote modifiers (!w, ffzHyper, etc.)",
+		hint: "Show text pollution from BTTV and FFZ emote modifiers (!w, ffzHyper, etc.). Modifiers are not supported yet, this setting only affects the display of their text form",
 		defaultValue: false,
 	}),
 	declareConfig("chat.mod_slider", "TOGGLE", {

--- a/src/site/twitch.tv/modules/chat/ChatModule.vue
+++ b/src/site/twitch.tv/modules/chat/ChatModule.vue
@@ -142,11 +142,11 @@ export const config = [
 		},
 		defaultValue: 1,
 	}),
-	declareConfig("chat.hide_emote_modifiers", "TOGGLE", {
+	declareConfig("chat.show_emote_modifiers", "TOGGLE", {
 		path: ["Chat", "Style"],
-		label: "Hide Emote Modifiers",
-		hint: "Hide BTTV and FFZ emote modifiers (!w, ffzHyper, etc.)",
-		defaultValue: true,
+		label: "Show Emote Modifiers",
+		hint: "Show BTTV and FFZ emote modifiers (!w, ffzHyper, etc.)",
+		defaultValue: false,
 	}),
 	declareConfig("chat.mod_slider", "TOGGLE", {
 		path: ["Chat", "Moderation"],

--- a/src/site/twitch.tv/modules/chat/ChatModule.vue
+++ b/src/site/twitch.tv/modules/chat/ChatModule.vue
@@ -142,6 +142,12 @@ export const config = [
 		},
 		defaultValue: 1,
 	}),
+	declareConfig("chat.hide_emote_modifiers", "TOGGLE", {
+		path: ["Chat", "Style"],
+		label: "Hide Emote Modifiers",
+		hint: "Hide BTTV and FFZ emote modifiers (!w, ffzHyper, etc.)",
+		defaultValue: true,
+	}),
 	declareConfig("chat.mod_slider", "TOGGLE", {
 		path: ["Chat", "Moderation"],
 		label: "Mod Slider",

--- a/src/site/twitch.tv/modules/chat/components/message/UserMessage.vue
+++ b/src/site/twitch.tv/modules/chat/components/message/UserMessage.vue
@@ -144,6 +144,7 @@ const meStyle = useConfig<number>("chat.slash_me_style");
 const highlightStyle = useConfig<number>("highlights.display_style");
 const highlightOpacity = useConfig<number>("highlights.opacity");
 const displaySecondsInTimestamp = useConfig<boolean>("chat.timestamp_with_seconds");
+const hideModifiers = useConfig<boolean>("chat.hide_emote_modifiers");
 
 // Get the locale to format the timestamp
 const locale = navigator.languages && navigator.languages.length ? navigator.languages[0] : navigator.language ?? "en";
@@ -166,6 +167,7 @@ function doTokenize() {
 		chatterMap: props.chatters ?? {},
 		emoteMap: props.emotes ?? {},
 		localEmoteMap: { ...cosmetics.emotes, ...props.msg.nativeEmotes },
+		hideModifiers: hideModifiers.value,
 	});
 
 	const result: MessageTokenOrText[] = [];

--- a/src/site/twitch.tv/modules/chat/components/message/UserMessage.vue
+++ b/src/site/twitch.tv/modules/chat/components/message/UserMessage.vue
@@ -144,7 +144,7 @@ const meStyle = useConfig<number>("chat.slash_me_style");
 const highlightStyle = useConfig<number>("highlights.display_style");
 const highlightOpacity = useConfig<number>("highlights.opacity");
 const displaySecondsInTimestamp = useConfig<boolean>("chat.timestamp_with_seconds");
-const hideModifiers = useConfig<boolean>("chat.hide_emote_modifiers");
+const showModifiers = useConfig<boolean>("chat.show_emote_modifiers");
 
 // Get the locale to format the timestamp
 const locale = navigator.languages && navigator.languages.length ? navigator.languages[0] : navigator.language ?? "en";
@@ -167,7 +167,7 @@ function doTokenize() {
 		chatterMap: props.chatters ?? {},
 		emoteMap: props.emotes ?? {},
 		localEmoteMap: { ...cosmetics.emotes, ...props.msg.nativeEmotes },
-		hideModifiers: hideModifiers.value,
+		showModifiers: showModifiers.value,
 	});
 
 	const result: MessageTokenOrText[] = [];


### PR DESCRIPTION
Adds a toggle option to show/hide BTTV and FFZ emote modifiers, implements #482 