### PR TITLE
added a option to hide the sub leaderboard

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -4,6 +4,7 @@
 
 -   Added a tooltip to show the full message when hovering over replies in chat
 -   Fixed tooltips of nametag paints appearing even if they are disabled
+-   Added a option to hide the Subscriber Leaderboard on top.
 
 ### Version 3.0.6.1000
 

--- a/src/site/twitch.tv/modules/chat/ChatController.vue
+++ b/src/site/twitch.tv/modules/chat/ChatController.vue
@@ -230,19 +230,22 @@ a.then(
 const gift_leaderboard = awaitComponents<Twitch.MessageCardOpeners>({
 	parentSelector: '[data-test-selector="channel-leaderboard-container"]',
 	predicate: (n) => {
-		if(hideGiftedSubsBanner.value){
+		if (hideGiftedSubsBanner.value) {
 			// Find the element with the data-test-selector attribute
 			const channelLeaderboard = document.querySelector('[data-test-selector="channel-leaderboard-container"]');
 
 			// Hide the element using CSS
 			if (channelLeaderboard) {
-			channelLeaderboard.setAttribute("style","display: none;");
+				channelLeaderboard.setAttribute("style","display: none;");
 			}
 		}
 		return n.props && (n.props.onShowViewerCard || n.openUserCard);
 	},
 });
 
+gift_leaderboard.then(
+	() => null,
+);
 
 if (a instanceof ObserverPromise) {
 	until(useTimeout(1e4))

--- a/src/site/twitch.tv/modules/chat/ChatController.vue
+++ b/src/site/twitch.tv/modules/chat/ChatController.vue
@@ -97,6 +97,7 @@ const tools = useChatTools(ctx);
 // line limit
 const lineLimit = useConfig("chat.line_limit", 150);
 const ignoreClearChat = useConfig<boolean>("chat.ignore_clear_chat");
+const hideGiftedSubsBanner = useConfig<boolean>("chat.hide_gifted_subs");
 
 // Defines the current channel for hooking
 const currentChannel = ref<CurrentChannel | null>(null);
@@ -225,6 +226,23 @@ a.then(
 	},
 	() => null,
 );
+
+const gift_leaderboard = awaitComponents<Twitch.MessageCardOpeners>({
+	parentSelector: '[data-test-selector="channel-leaderboard-container"]',
+	predicate: (n) => {
+		if(hideGiftedSubsBanner.value){
+			// Find the element with the data-test-selector attribute
+			const channelLeaderboard = document.querySelector('[data-test-selector="channel-leaderboard-container"]');
+
+			// Hide the element using CSS
+			if (channelLeaderboard) {
+			channelLeaderboard.setAttribute("style","display: none;");
+			}
+		}
+		return n.props && (n.props.onShowViewerCard || n.openUserCard);
+	},
+});
+
 
 if (a instanceof ObserverPromise) {
 	until(useTimeout(1e4))

--- a/src/site/twitch.tv/modules/chat/ChatController.vue
+++ b/src/site/twitch.tv/modules/chat/ChatController.vue
@@ -236,16 +236,14 @@ const gift_leaderboard = awaitComponents<Twitch.MessageCardOpeners>({
 
 			// Hide the element using CSS
 			if (channelLeaderboard) {
-				channelLeaderboard.setAttribute("style","display: none;");
+				channelLeaderboard.setAttribute("style", "display: none;");
 			}
 		}
 		return n.props && (n.props.onShowViewerCard || n.openUserCard);
 	},
 });
 
-gift_leaderboard.then(
-	() => null,
-);
+gift_leaderboard.then(() => null);
 
 if (a instanceof ObserverPromise) {
 	until(useTimeout(1e4))

--- a/src/site/twitch.tv/modules/chat/ChatModule.vue
+++ b/src/site/twitch.tv/modules/chat/ChatModule.vue
@@ -433,5 +433,11 @@ export const config = [
 		hint: "Whether or not to display nametag paints",
 		defaultValue: true,
 	}),
+	declareConfig("chat.hide_gifted_subs", "TOGGLE", {
+		path: ["Chat", "Style"],
+		label: "Hide Gifted Subscribers Banner",
+		hint: "Hides the gifted subscriber banner on top of chat",
+		defaultValue: false,
+	}),
 ];
 </script>


### PR DESCRIPTION
Added a option to hide the Subscriber Leaderboard on top of chat.
This is in response to #458 and #467