### PR TITLE
Automatically close emote menu after selection

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -2,7 +2,8 @@
 
 **The changes listed here are not assigned to an official release**.
 
--   Automatically close emote menu after selection, unless shift key is held down
+-   Automatically close the emote menu after sending a chat message
+-   Added option to automatically close emote menu after making a selection, unless the shift key is held down
 -   Added a tooltip to show the full message when hovering over replies in chat
 -   Fixed tooltips of nametag paints appearing even if they are disabled
 

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -2,6 +2,7 @@
 
 **The changes listed here are not assigned to an official release**.
 
+-   Automatically close emote menu after selection, unless shift key is held down
 -   Added a tooltip to show the full message when hovering over replies in chat
 -   Fixed tooltips of nametag paints appearing even if they are disabled
 

--- a/src/site/twitch.tv/modules/emote-menu/EmoteMenu.vue
+++ b/src/site/twitch.tv/modules/emote-menu/EmoteMenu.vue
@@ -137,6 +137,8 @@ onKeyStroke("e", (ev) => {
 	ev.preventDefault();
 });
 
+const { hide } = useTooltip();
+
 // Toggle the menu's visibility
 function toggle(native?: boolean) {
 	const t = props.instance.component;
@@ -148,6 +150,7 @@ function toggle(native?: boolean) {
 
 	if (ctx.open) {
 		t.props.closeEmotePicker();
+		hide();
 	} else {
 		t.props.clearMenus();
 		t.closeBitsCard();
@@ -196,8 +199,6 @@ function onProviderVisibilityChange(provider: EmoteMenuTabName, visible: boolean
 	}
 }
 
-const { hide } = useTooltip();
-
 const isShift = useKeyModifier("Shift", { initial: false });
 function onEmoteClick(emote: SevenTV.ActiveEmote) {
 	const inputRef = props.instance.component.autocompleteInputRef;
@@ -217,7 +218,6 @@ function onEmoteClick(emote: SevenTV.ActiveEmote) {
 	if (shouldCloseAfterSelection.value) {
 		if (!isShift.value) {
 			toggle();
-			hide();
 		}
 	}
 }
@@ -255,6 +255,15 @@ onClickOutside(containerRef, (e) => {
 	}
 
 	ctx.open = false;
+});
+
+//Close menu when chat message sent. Message send determined by enter pressed + chat input has focus
+onKeyStroke("Enter", () => {
+	let isChatInputFocused = document.activeElement?.getAttribute("data-a-target") === "chat-input";
+
+	if (ctx.open && isChatInputFocused) {
+		toggle();
+	}
 });
 
 // Capture anchor / input elements

--- a/src/site/twitch.tv/modules/emote-menu/EmoteMenu.vue
+++ b/src/site/twitch.tv/modules/emote-menu/EmoteMenu.vue
@@ -66,6 +66,7 @@ import { useChannelContext } from "@/composable/channel/useChannelContext";
 import { useChatEmotes } from "@/composable/chat/useChatEmotes";
 import { getModuleRef } from "@/composable/useModule";
 import { useConfig } from "@/composable/useSettings";
+import { useTooltip } from "@/composable/useTooltip";
 import { useSettingsMenu } from "@/site/global/settings/Settings";
 import SearchIcon from "@/assets/svg/icons/SearchIcon.vue";
 import StarIcon from "@/assets/svg/icons/StarIcon.vue";
@@ -75,7 +76,6 @@ import { useEmoteMenuContext } from "./EmoteMenuContext";
 import EmoteMenuTab from "./EmoteMenuTab.vue";
 import UiFloating from "@/ui/UiFloating.vue";
 import { shift } from "@floating-ui/dom";
-import { useTooltip } from "@/composable/useTooltip";
 
 export type EmoteMenuTabName = SevenTV.Provider | "FAVORITE";
 
@@ -217,7 +217,6 @@ function onEmoteClick(emote: SevenTV.ActiveEmote) {
 		toggle();
 		hide();
 	}
-	
 }
 
 defineFunctionHook(props.instance.component, "onBitsIconClick", function (old) {

--- a/src/site/twitch.tv/modules/emote-menu/EmoteMenu.vue
+++ b/src/site/twitch.tv/modules/emote-menu/EmoteMenu.vue
@@ -259,7 +259,7 @@ onClickOutside(containerRef, (e) => {
 
 //Close menu when chat message sent. Message send determined by enter pressed + chat input has focus
 onKeyStroke("Enter", () => {
-	let isChatInputFocused = document.activeElement?.getAttribute("data-a-target") === "chat-input";
+	const isChatInputFocused = document.activeElement?.getAttribute("data-a-target") === "chat-input";
 
 	if (ctx.open && isChatInputFocused) {
 		toggle();

--- a/src/site/twitch.tv/modules/emote-menu/EmoteMenu.vue
+++ b/src/site/twitch.tv/modules/emote-menu/EmoteMenu.vue
@@ -75,6 +75,7 @@ import { useEmoteMenuContext } from "./EmoteMenuContext";
 import EmoteMenuTab from "./EmoteMenuTab.vue";
 import UiFloating from "@/ui/UiFloating.vue";
 import { shift } from "@floating-ui/dom";
+import { useTooltip } from "@/composable/useTooltip";
 
 export type EmoteMenuTabName = SevenTV.Provider | "FAVORITE";
 
@@ -194,6 +195,9 @@ function onProviderVisibilityChange(provider: EmoteMenuTabName, visible: boolean
 	}
 }
 
+const { hide } = useTooltip();
+
+const isShift = useKeyModifier("Shift", { initial: false });
 function onEmoteClick(emote: SevenTV.ActiveEmote) {
 	const inputRef = props.instance.component.autocompleteInputRef;
 	if (!inputRef) return log.warn("ref to input not found, cannot insert emote");
@@ -208,6 +212,12 @@ function onEmoteClick(emote: SevenTV.ActiveEmote) {
 
 	inputRef.setValue(current + (emote.unicode ?? emote.name) + " ");
 	props.instance.component.chatInputRef.focus();
+
+	if (!isShift.value) {
+		toggle();
+		hide();
+	}
+	
 }
 
 defineFunctionHook(props.instance.component, "onBitsIconClick", function (old) {

--- a/src/site/twitch.tv/modules/emote-menu/EmoteMenu.vue
+++ b/src/site/twitch.tv/modules/emote-menu/EmoteMenu.vue
@@ -99,6 +99,7 @@ const searchInputRef = ref<HTMLInputElement | undefined>();
 
 const isSearchInputEnabled = useConfig<boolean>("ui.emote_menu_search");
 const usage = useConfig<Map<string, number>>("ui.emote_menu.usage");
+const shouldCloseAfterSelection = useConfig<Map<string, number>>("ui.emote_menu.close_after_selection");
 
 const activeProvider = ref<EmoteMenuTabName | null>("7TV");
 const visibleProviders = reactive<Record<EmoteMenuTabName, boolean>>({
@@ -213,9 +214,11 @@ function onEmoteClick(emote: SevenTV.ActiveEmote) {
 	inputRef.setValue(current + (emote.unicode ?? emote.name) + " ");
 	props.instance.component.chatInputRef.focus();
 
-	if (!isShift.value) {
-		toggle();
-		hide();
+	if (shouldCloseAfterSelection.value) {
+		if (!isShift.value) {
+			toggle();
+			hide();
+		}
 	}
 }
 

--- a/src/site/twitch.tv/modules/emote-menu/EmoteMenuModule.vue
+++ b/src/site/twitch.tv/modules/emote-menu/EmoteMenuModule.vue
@@ -76,6 +76,12 @@ markAsReady();
 
 <script lang="ts">
 export const config = [
+	declareConfig("ui.emote_menu.close_after_selection", "TOGGLE", {
+		path: ["Appearance", "Interface"],
+		label: "Close Emote Menu After Selection",
+		hint: "Automatically close the emote menu after making a selection, unless the shift key is held down",
+		defaultValue: false,
+	}),
 	declareConfig("ui.emote_menu_search", "TOGGLE", {
 		path: ["Appearance", "Interface"],
 		label: "Emote Menu: Live Input Search",


### PR DESCRIPTION
It's annoying to have do an extra click to close the emote menu after making your selection, this change automatically closes it after clicking an emote.

If the user wants to select multiple emotes, they can hold shift while clicking. This is the same way BTTV menu works.