### PR TITLE
feat: add username highlight

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -4,6 +4,7 @@
 
 -   Added a tooltip to show the full message when hovering over replies in chat
 -   Fixed tooltips of nametag paints appearing even if they are disabled
+-   Added an option to highlight chat messages from specific usernames
 
 ### Version 3.0.6.1000
 

--- a/src/composable/chat/useChatHighlights.ts
+++ b/src/composable/chat/useChatHighlights.ts
@@ -20,6 +20,7 @@ export interface HighlightDef {
 	regexp?: boolean;
 	readonly cachedRegExp?: RegExp;
 
+	highlightType?: "username" | "message";
 	color: string;
 	label: string;
 	caseSensitive?: boolean;
@@ -163,11 +164,17 @@ export function useChatHighlights(ctx: ChannelContext) {
 				}
 			}
 
-			ok = regexp.test(msg.body);
+			ok = h.highlightType === "username" ? regexp.test(msg.author!.username) : regexp.test(msg.body);
 		} else if (h.pattern) {
-			ok = h.caseSensitive
-				? msg.body.includes(h.pattern)
-				: msg.body.toLowerCase().includes(h.pattern.toLowerCase());
+			if (h.highlightType === "username") {
+				ok = h.caseSensitive
+					? msg.author?.username.includes(h.pattern)
+					: msg.author?.username.toLowerCase().includes(h.pattern.toLowerCase());
+			} else {
+				ok = h.caseSensitive
+					? msg.body.includes(h.pattern)
+					: msg.body.toLowerCase().includes(h.pattern.toLowerCase());
+			}
 		} else if (typeof h.test === "function") {
 			ok = h.test(msg);
 		}

--- a/src/composable/chat/useChatHighlights.ts
+++ b/src/composable/chat/useChatHighlights.ts
@@ -164,12 +164,20 @@ export function useChatHighlights(ctx: ChannelContext) {
 				}
 			}
 
-			ok = h.highlightType === "username" ? regexp.test(msg.author!.username) : regexp.test(msg.body);
+			if (h.highlightType === "username") {
+				if (msg.author) {
+					ok = regexp.test(msg.author.username);
+				}
+			} else {
+				ok = regexp.test(msg.body);
+			}
 		} else if (h.pattern) {
 			if (h.highlightType === "username") {
-				ok = h.caseSensitive
-					? msg.author?.username.includes(h.pattern)
-					: msg.author?.username.toLowerCase().includes(h.pattern.toLowerCase());
+				if (msg.author) {
+					ok = h.caseSensitive
+						? msg.author.username.includes(h.pattern)
+						: msg.author.username.toLowerCase().includes(h.pattern.toLowerCase());
+				}
 			} else {
 				ok = h.caseSensitive
 					? msg.body.includes(h.pattern)

--- a/src/site/global/components/FormDropdown.vue
+++ b/src/site/global/components/FormDropdown.vue
@@ -1,0 +1,13 @@
+<template>
+	<select>
+		<option disabled value="">Select one</option>
+		<!-- It's fine to use index as key because the order of the options won't change -->
+		<option v-for="(s, i) in options" :key="i" :value="s">{{ s }}</option>
+	</select>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+	options: string[];
+}>();
+</script>

--- a/src/site/global/settings/SettingsConfigHighlights.vue
+++ b/src/site/global/settings/SettingsConfigHighlights.vue
@@ -5,6 +5,7 @@
 			<div class="item heading">
 				<div>Pattern</div>
 				<div>Label</div>
+				<div>Highlight Type</div>
 				<div class="centered">Flash Title</div>
 				<div class="centered">RegExp</div>
 				<div>Case Sensitive</div>
@@ -31,6 +32,15 @@
 								:ref="(c) => inputs.label.set(h, c as InstanceType<typeof FormInput>)"
 								v-model="h.label"
 								@blur="onInputBlur(h, 'label')"
+							/>
+						</div>
+
+						<!-- Dropdown: Highlight Type (username or message) -->
+						<div name="highlight-type">
+							<FormDropdown
+								:value="h.highlightType ?? `message`"
+								:options="[`message`, `username`]"
+								@change="onHighlightTypeChange(h, $event)"
 							/>
 						</div>
 
@@ -112,6 +122,7 @@ import CompactDiscIcon from "@/assets/svg/icons/CompactDiscIcon.vue";
 import UiFloating from "@/ui/UiFloating.vue";
 import UiScrollable from "@/ui/UiScrollable.vue";
 import FormCheckbox from "../components/FormCheckbox.vue";
+import FormDropdown from "../components/FormDropdown.vue";
 import FormInput from "../components/FormInput.vue";
 import { v4 as uuid } from "uuid";
 
@@ -138,6 +149,13 @@ function onInputBlur(h: HighlightDef, inputName: keyof typeof inputs): void {
 
 	const id = uuid();
 	highlights.updateId("new-highlight", id);
+	highlights.save();
+}
+
+function onHighlightTypeChange(h: HighlightDef, ev: InputEvent) {
+	if (!(ev.target instanceof HTMLSelectElement)) return;
+
+	h.highlightType = ev.target.value as HighlightDef["highlightType"];
 	highlights.save();
 }
 
@@ -265,7 +283,7 @@ main.seventv-settings-custom-highlights {
 		.item {
 			display: grid;
 			grid-auto-flow: row dense;
-			grid-template-columns: 20% 9rem 1fr 1fr 1fr 1fr 1fr;
+			grid-template-columns: 20% 9rem 5.5rem 1fr 1fr 1fr 1fr 1fr;
 			column-gap: 3rem;
 			padding: 1rem;
 
@@ -311,6 +329,10 @@ main.seventv-settings-custom-highlights {
 						height: initial;
 					}
 				}
+			}
+
+			[name="highlight-type"] > select {
+				max-width: 120%;
 			}
 
 			[name="color"] > input {

--- a/src/site/global/settings/SettingsMenu.vue
+++ b/src/site/global/settings/SettingsMenu.vue
@@ -397,7 +397,7 @@ watch(
 	}
 }
 .seventv-settings-settings-area {
-	width: 80rem;
+	width: 85rem;
 	max-height: 60rem;
 }
 </style>


### PR DESCRIPTION
This PR is created to add a custom highlight feature for usernames.

### What this PR does
- Adds a new field of `highlightType` to highlight
- Adds a new field (column) to the highlight setting menu
- Adds a dropdown to let users pick which highlight type they want. However, it's **unstyled**.
- Adds a very simple dropdown component to support it
- Increases the width of the settings area. However, the dropdown (the select element) is still a bit concatenated because I don't want to increase the width too much.

The idea of using dropdown is from BTTV. If you have a better alternative, please do tell me.

If you're still unsatisfied with some of these, I'd be happy to discuss and improve these changes!

Final outlook:
<img width="839" alt="Screenshot 2023-04-27 at 15 23 27" src="https://user-images.githubusercontent.com/53994055/234812899-6e33728c-44d1-4d28-84d7-7afbb3d51967.png">

Closes #473 