### PR TITLE
Handle YouTube Chat Iframe without `all_frames`

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -4,6 +4,7 @@
 
 -   Added a tooltip to show the full message when hovering over replies in chat
 -   Fixed tooltips of nametag paints appearing even if they are disabled
+-   Reinstated functionality on youtube.com
 
 ### Version 3.0.6.1000
 

--- a/src/common/Constant.ts
+++ b/src/common/Constant.ts
@@ -14,6 +14,7 @@ export const SITE_NAV_PATHNAME: InjectionKey<Ref<string>> = Symbol("seventv-site
 export const SITE_WORKER_URL: InjectionKey<string> = Symbol("seventv-site-worker-url");
 export const SITE_ASSETS_URL: InjectionKey<string> = Symbol("seventv-site-assets-url");
 export const SITE_EXT_OPTIONS_URL: InjectionKey<string> = Symbol("seventv-site-ext-options-url");
+export const SITE_ACTIVE_WINDOW: InjectionKey<Window> = Symbol("seventv-site-active-window");
 
 export const UNICODE_TAG_0 = "\u{E0000}";
 export const UNICODE_TAG_0_REGEX = new RegExp(UNICODE_TAG_0, "g");

--- a/src/site/App.vue
+++ b/src/site/App.vue
@@ -82,7 +82,10 @@ bc.addEventListener("message", (ev) => {
 	);
 
 	for (const node of newNodes) {
-		useConfig(node.key).value = node.value;
+		const n = useConfig(node.key);
+		if (!n || !n.value) continue;
+
+		n.value = node.value;
 	}
 });
 

--- a/src/site/youtube.com/YouTubeSite.vue
+++ b/src/site/youtube.com/YouTubeSite.vue
@@ -22,6 +22,7 @@ store.setPlatform("YOUTUBE", []);
 
 // Import modules
 const modules = import.meta.glob("./modules/**/*Module.vue", { eager: true, import: "default" });
+
 for (const key in modules) {
 	const modPath = key.split("/");
 	const modKey = modPath.splice(modPath.length - 2, 1).pop();

--- a/src/site/youtube.com/modules/chat/ChatAutocomplete.vue
+++ b/src/site/youtube.com/modules/chat/ChatAutocomplete.vue
@@ -1,17 +1,20 @@
 <template />
 
 <script setup lang="ts">
-import { ref, watch } from "vue";
-import { defineFunctionHook } from "@/common/Reflection";
+import { ref, watch, watchEffect } from "vue";
+import { defineFunctionHook, unsetPropertyHook } from "@/common/Reflection";
 import { useChannelContext } from "@/composable/channel/useChannelContext";
 import { useChatEmotes } from "@/composable/chat/useChatEmotes";
+
+const props = defineProps<{
+	w: Window;
+}>();
 
 const ctx = useChannelContext();
 const emotes = useChatEmotes(ctx);
 
-const InputFieldRenderer = await customElements.whenDefined("yt-live-chat-text-input-field-renderer");
-
-const inputField = new InputFieldRenderer() as YouTube.LiveChatTextInputFieldRenderer;
+const InputFieldRenderer = ref<CustomElementConstructor | null>(null);
+const inputField = ref<YouTube.LiveChatTextInputFieldRenderer | null>(null);
 
 // Create a list of all emotes
 const emoteList = ref<SevenTV.ActiveEmote[]>([]);
@@ -23,39 +26,56 @@ watch(emotes.active, () => {
 	];
 });
 
-defineFunctionHook(inputField.constructor.prototype, "getSuggestions", function (this, old, term: string) {
-	const result = old?.apply(this, [term]) as { suggestion: YouTube.ChatSuggestion }[];
-	if (!result || !Array.isArray(result)) return;
+watchEffect(async () => {
+	InputFieldRenderer.value = await props.w.customElements.whenDefined("yt-live-chat-text-input-field-renderer");
 
-	// Filter to term
-	const query = term.toLowerCase().slice(1);
-	const emotes = emoteList.value.filter((ae) => ae.name.toLowerCase().includes(query));
-
-	result.push(
-		...emotes.map((e) => ({
-			suggestion: {
-				alt: e.name,
-				emoji: true,
-				text: e.name,
-				textToInsertWhenSelected: e.name,
-				image: {
-					accessibility: {
-						accessibilityData: {
-							label: e.name,
-						},
-					},
-					thumbnails: e.data?.host.files
-						.filter((f) => f.format === e.data!.host.files[0].format)
-						.map((f) => ({
-							url: `${e.data!.host.url}/${f.name}`,
-							width: f.width,
-							height: f.height,
-						})),
-				},
-			} as YouTube.ChatSuggestion,
-		})),
-	);
-
-	return result;
+	inputField.value = new InputFieldRenderer.value() as YouTube.LiveChatTextInputFieldRenderer;
 });
+
+watch(
+	inputField,
+	(inp, old) => {
+		if (old) {
+			unsetPropertyHook(old, "getSuggestions");
+		}
+		if (!inp) return;
+
+		defineFunctionHook(inp.constructor.prototype, "getSuggestions", function (this, old, term: string) {
+			const result = old?.apply(this, [term]) as { suggestion: YouTube.ChatSuggestion }[];
+			if (!result || !Array.isArray(result)) return;
+
+			// Filter to term
+			const query = term.toLowerCase().slice(1);
+			const emotes = emoteList.value.filter((ae) => ae.name.toLowerCase().includes(query));
+
+			result.push(
+				...emotes.map((e) => ({
+					suggestion: {
+						alt: e.name,
+						emoji: true,
+						text: e.name,
+						textToInsertWhenSelected: e.name,
+						image: {
+							accessibility: {
+								accessibilityData: {
+									label: e.name,
+								},
+							},
+							thumbnails: e.data?.host.files
+								.filter((f) => f.format === e.data!.host.files[0].format)
+								.map((f) => ({
+									url: `${e.data!.host.url}/${f.name}`,
+									width: f.width,
+									height: f.height,
+								})),
+						},
+					} as YouTube.ChatSuggestion,
+				})),
+			);
+
+			return result;
+		});
+	},
+	{ immediate: true },
+);
 </script>

--- a/src/site/youtube.com/modules/chat/ChatAutocomplete.vue
+++ b/src/site/youtube.com/modules/chat/ChatAutocomplete.vue
@@ -28,6 +28,7 @@ watch(emotes.active, () => {
 
 watchEffect(async () => {
 	InputFieldRenderer.value = await props.w.customElements.whenDefined("yt-live-chat-text-input-field-renderer");
+	if (!InputFieldRenderer.value) return;
 
 	inputField.value = new InputFieldRenderer.value() as YouTube.LiveChatTextInputFieldRenderer;
 });

--- a/src/site/youtube.com/modules/chat/ChatController.vue
+++ b/src/site/youtube.com/modules/chat/ChatController.vue
@@ -1,6 +1,6 @@
 <template>
 	<ChatData />
-	<ChatAutocomplete />
+	<ChatAutocomplete :w="w" />
 </template>
 
 <script setup lang="ts">
@@ -12,6 +12,7 @@ import ChatAutocomplete from "./ChatAutocomplete.vue";
 import ChatData from "./ChatData.vue";
 
 const props = defineProps<{
+	w: Window;
 	channelId: string;
 	chatList: YouTube.LiveChatItemListRenderer;
 }>();

--- a/src/site/youtube.com/modules/chat/ChatController.vue
+++ b/src/site/youtube.com/modules/chat/ChatController.vue
@@ -4,6 +4,7 @@
 </template>
 
 <script setup lang="ts">
+import { watchEffect } from "vue";
 import { defineFunctionHook } from "@/common/Reflection";
 import { AnyToken, ChatMessage, EmoteToken } from "@/common/chat/ChatMessage";
 import { useChannelContext } from "@/composable/channel/useChannelContext";
@@ -22,131 +23,139 @@ const emotes = useChatEmotes(ctx);
 
 const seenEmojis = {} as Record<string, SevenTV.ActiveEmote>;
 
-defineFunctionHook(
-	props.chatList.constructor.prototype,
-	"handleAddChatItemAction_",
-	function (this, old, item: YouTube.LiveChatItem) {
-		if (!item || !item.item || !item.item.liveChatTextMessageRenderer?.message) return old?.apply(this, [item]);
-		const msg = new ChatMessage(item.clientId ?? item.clientMessageId ?? "");
+watchEffect(() => {
+	ctx.setCurrentChannel({
+		id: props.channelId,
+		displayName: "",
+		username: "",
+	});
 
-		// Deconstruct the message into a simple text body
-		for (const tok of item.item.liveChatTextMessageRenderer.message.runs) {
-			if (tok.text) msg.body += tok.text;
-			else if (tok.emoji) {
-				const label = tok.emoji.image.accessibility.accessibilityData.label;
+	defineFunctionHook(
+		props.chatList.constructor.prototype,
+		"handleAddChatItemAction_",
+		function (this, old, item: YouTube.LiveChatItem) {
+			if (!item || !item.item || !item.item.liveChatTextMessageRenderer?.message) return old?.apply(this, [item]);
+			const msg = new ChatMessage(item.clientId ?? item.clientMessageId ?? "");
 
-				msg.body += label;
-				if (!seenEmojis[label]) {
-					// emoji tokens are converted to our format for the tokenizer
-					seenEmojis[label] = {
-						id: tok.emoji.emojiId,
-						name: label,
-						data: {
+			// Deconstruct the message into a simple text body
+			for (const tok of item.item.liveChatTextMessageRenderer.message.runs) {
+				if (tok.text) msg.body += tok.text;
+				else if (tok.emoji) {
+					const label = tok.emoji.image.accessibility.accessibilityData.label;
+
+					msg.body += label;
+					if (!seenEmojis[label]) {
+						// emoji tokens are converted to our format for the tokenizer
+						seenEmojis[label] = {
 							id: tok.emoji.emojiId,
 							name: label,
-							owner: null,
-							host: {
-								url: "",
-								files: tok.emoji.image.thumbnails.map((im) => ({
-									name: im.url,
-									width: im.width,
-									height: im.height,
-									format: "PNG",
-								})),
-							},
-						},
-					};
-				}
-			}
-		}
-
-		// Native tokens are cleared as we will now rebuild the message
-		const nativeTokens = item.item.liveChatTextMessageRenderer.message.runs;
-		nativeTokens.length = 0;
-
-		// Set up our tokenizer instance
-		const tokenizer = msg.getTokenizer();
-		const tokens =
-			tokenizer?.tokenize({
-				emoteMap: { ...emotes.active, ...seenEmojis },
-				chatterMap: {},
-			}) ?? [];
-
-		// Build the message tokens
-		const result: MessageTokenOrText[] = [];
-		const text = msg.body;
-
-		let lastOffset = 0;
-		for (const tok of tokens) {
-			const start = tok.range[0];
-			const end = tok.range[1];
-
-			const before = text.substring(lastOffset, start);
-			if (before) {
-				result.push(before);
-			}
-
-			result.push(tok);
-
-			lastOffset = end + 1;
-		}
-
-		const after = text.substring(lastOffset);
-		if (after) {
-			result.push(after);
-		}
-
-		// Re-construct the message
-		for (const tok of result) {
-			if (typeof tok === "string") {
-				nativeTokens.push({
-					text: tok,
-				});
-
-				continue;
-			}
-
-			switch (tok.kind) {
-				case "EMOTE": {
-					const data = tok.content as EmoteToken["content"];
-					if (!data.emote || !data.emote.data) break;
-
-					const isApp = !seenEmojis[data.emote.name];
-					const host = data.emote.data.host;
-
-					nativeTokens.push({
-						emoji: {
-							emojiId: isApp ? `seventv:${data.emote.id}` : data.emote.id,
-							image: {
-								accessibility: {
-									accessibilityData: {
-										label: data.emote.name,
-									},
-								},
-								thumbnails: host.files
-									.filter((f) => f.format === host.files[0].format)
-									.slice(0, 2)
-									.map((f) => ({
-										url: host.url ? `${host.url}/${f.name}` : f.name,
-										width: f.width,
-										height: f.height,
+							data: {
+								id: tok.emoji.emojiId,
+								name: label,
+								owner: null,
+								host: {
+									url: "",
+									files: tok.emoji.image.thumbnails.map((im) => ({
+										name: im.url,
+										width: im.width,
+										height: im.height,
+										format: "PNG",
 									})),
+								},
 							},
-							isCustomEmoji: true,
-						},
-					});
-					break;
+						};
+					}
+				}
+			}
+
+			// Native tokens are cleared as we will now rebuild the message
+			const nativeTokens = item.item.liveChatTextMessageRenderer.message.runs;
+			nativeTokens.length = 0;
+
+			// Set up our tokenizer instance
+			const tokenizer = msg.getTokenizer();
+			const tokens =
+				tokenizer?.tokenize({
+					emoteMap: { ...emotes.active, ...seenEmojis },
+					chatterMap: {},
+				}) ?? [];
+
+			// Build the message tokens
+			const result: MessageTokenOrText[] = [];
+			const text = msg.body;
+
+			let lastOffset = 0;
+			for (const tok of tokens) {
+				const start = tok.range[0];
+				const end = tok.range[1];
+
+				const before = text.substring(lastOffset, start);
+				if (before) {
+					result.push(before);
 				}
 
-				default:
-					break;
-			}
-		}
+				result.push(tok);
 
-		// pass it back to youtube to be rendered
-		return old?.apply(this, [item]);
-	},
-);
+				lastOffset = end + 1;
+			}
+
+			const after = text.substring(lastOffset);
+			if (after) {
+				result.push(after);
+			}
+
+			// Re-construct the message
+			for (const tok of result) {
+				if (typeof tok === "string") {
+					nativeTokens.push({
+						text: tok,
+					});
+
+					continue;
+				}
+
+				switch (tok.kind) {
+					case "EMOTE": {
+						const data = tok.content as EmoteToken["content"];
+						if (!data.emote || !data.emote.data) break;
+
+						const isApp = !seenEmojis[data.emote.name];
+						const host = data.emote.data.host;
+
+						nativeTokens.push({
+							emoji: {
+								emojiId: isApp ? `seventv:${data.emote.id}` : data.emote.id,
+								image: {
+									accessibility: {
+										accessibilityData: {
+											label: data.emote.name,
+										},
+									},
+									thumbnails: host.files
+										.filter((f) => f.format === host.files[0].format)
+										.slice(0, 2)
+										.map((f) => ({
+											url: host.url ? `${host.url}/${f.name}` : f.name,
+											width: f.width,
+											height: f.height,
+										})),
+								},
+								isCustomEmoji: true,
+							},
+						});
+						break;
+					}
+
+					default:
+						break;
+				}
+			}
+
+			// pass it back to youtube to be rendered
+			return old?.apply(this, [item]);
+		},
+	);
+});
 
 type MessageTokenOrText = AnyToken | string;
 </script>

--- a/src/site/youtube.com/modules/chat/ChatModule.vue
+++ b/src/site/youtube.com/modules/chat/ChatModule.vue
@@ -82,12 +82,12 @@ watchEffect(() => {
 				}
 				// in prod mode we apply the single-file stylesheet from the main document
 				case "LINK": {
-					if (sheet.id === "seventv-stylesheet") break;
+					if (sheet.id !== "seventv-stylesheet") break;
 
 					const link = (x = document.createElement("link"));
 					link.rel = "stylesheet";
 					link.href = (sheet as HTMLLinkElement).href;
-					link.id = "seventv-stylesheet";
+					link.id = sheet.id;
 					break;
 				}
 			}

--- a/src/site/youtube.com/modules/chat/ChatModule.vue
+++ b/src/site/youtube.com/modules/chat/ChatModule.vue
@@ -1,11 +1,12 @@
 <template>
 	<template v-if="chatList && channelID">
-		<ChatController :chat-list="chatList" :channel-id="channelID" />
+		<ChatController :w="w" :chat-list="chatList" :channel-id="channelID" />
 	</template>
 </template>
 
 <script setup lang="ts">
-import { ref } from "vue";
+import { ref, watchEffect } from "vue";
+import { useIntervalFn } from "@vueuse/core";
 import { decodeYoutubeParams } from "@/common/Decode";
 import { declareModule } from "@/composable/useModule";
 import ChatController from "./ChatController.vue";
@@ -16,17 +17,32 @@ const { markAsReady } = declareModule("chat", {
 });
 
 const channelID = ref("");
+const w = ref(window);
+const ChatList = ref<CustomElementConstructor | null>(null);
+const chatList = ref<YouTube.LiveChatItemListRenderer | null>(null);
+const ChatInput = ref<CustomElementConstructor | null>(null);
 
-const ChatList = await customElements.whenDefined("yt-live-chat-item-list-renderer");
+useIntervalFn(
+	async () => {
+		const frames = window.frames as unknown as Record<string, HTMLIFrameElement | undefined>;
 
-const chatList = new ChatList() as YouTube.LiveChatItemListRenderer;
+		const f = frames["chatframe"];
 
-async function captureChannelId(): Promise<void> {
-	await customElements.whenDefined("yt-live-chat-message-input-renderer");
-	const input = document.querySelector<YouTube.LiveChatMessageInputRenderer>("yt-live-chat-message-input-renderer");
+		w.value = (f ? f.contentWindow : window) as Window & typeof globalThis;
+		ChatList.value = await w.value.customElements.whenDefined("yt-live-chat-item-list-renderer");
+		ChatInput.value = await w.value.customElements.whenDefined("yt-live-chat-message-input-renderer");
+	},
+	1e3,
+	{
+		immediateCallback: true,
+	},
+);
+
+async function captureChannelId(w: Window): Promise<void> {
+	const input = w.document.querySelector<YouTube.LiveChatMessageInputRenderer>("yt-live-chat-message-input-renderer");
 	if (!input) {
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
-		const yt = (window as any).yt;
+		const yt = (w as any).yt;
 
 		channelID.value = yt?.config_?.CHANNEL_ID ?? "";
 		return;
@@ -38,7 +54,51 @@ async function captureChannelId(): Promise<void> {
 	channelID.value = decoded;
 }
 
-captureChannelId();
+watchEffect(() => {
+	if (!w.value) return;
+	if (!ChatList.value) return;
+
+	chatList.value = new ChatList.value() as YouTube.LiveChatItemListRenderer;
+
+	// Apply stylesheet to frame
+	const sheets = window.document.querySelectorAll<HTMLLinkElement | HTMLStyleElement>(
+		"#seventv-stylesheet, [data-vite-dev-id]",
+	);
+
+	// if inside an iframe we must port styles to it
+	if (sheets.length && w.value.frameElement) {
+		sheets.forEach((sheet) => {
+			let x: HTMLLinkElement | HTMLStyleElement | undefined;
+
+			switch (sheet.tagName) {
+				// in dev mode we apply vite's generated stylesheets
+				case "STYLE": {
+					if (!sheet.dataset.viteDevId) break;
+
+					const style = (x = document.createElement("style"));
+					style.appendChild(document.createTextNode(sheet.innerHTML));
+
+					break;
+				}
+				// in prod mode we apply the single-file stylesheet from the main document
+				case "LINK": {
+					if (sheet.id === "seventv-stylesheet") break;
+
+					const link = (x = document.createElement("link"));
+					link.rel = "stylesheet";
+					link.href = (sheet as HTMLLinkElement).href;
+					link.id = "seventv-stylesheet";
+					break;
+				}
+			}
+			if (!x) return;
+
+			w.value.document.head.appendChild(x);
+		});
+	}
+
+	captureChannelId(w.value);
+});
 
 markAsReady();
 </script>


### PR DESCRIPTION
This changes how youtube is hooked to query `chatframe` from `window.frames` and scoping to the inner window's frame content. 

This reinstates youtube functionality which was previously disabled in v3.0.3.