### PR TITLE
Added "focus on chatter" feature

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -2,6 +2,7 @@
 
 **The changes listed here are not assigned to an official release**.
 
+-   Added the ability to double click on a username in chat to dim all others, so you can easily see messages from that user.
 -   Added a tooltip to show the full message when hovering over replies in chat
 -   Fixed tooltips of nametag paints appearing even if they are disabled
 -   Reinstated functionality on youtube.com

--- a/src/composable/chat/useChatTools.ts
+++ b/src/composable/chat/useChatTools.ts
@@ -33,9 +33,7 @@ export function useChatTools(ctx: ChannelContext) {
 
 	function openViewerCard(e: MouseEvent, username: string, msgID: string, currentTarget?: EventTarget | null) {
 		// If not handled synchronously, MouseEvent.currentTarget becomes null. Allow callers to pass in currentTarget optionally to solve this.
-		let target = e.currentTarget ? e.currentTarget : currentTarget;
-
-		console.log(target, currentTarget);
+		const target = e.currentTarget ? e.currentTarget : currentTarget;
 
 		if (!data || !e || !target || !username) return false;
 

--- a/src/composable/chat/useChatTools.ts
+++ b/src/composable/chat/useChatTools.ts
@@ -31,10 +31,15 @@ export function useChatTools(ctx: ChannelContext) {
 		data[platorm][key] = value;
 	}
 
-	function openViewerCard(e: MouseEvent, username: string, msgID: string) {
-		if (!data || !e || !e.currentTarget || !username) return false;
+	function openViewerCard(e: MouseEvent, username: string, msgID: string, currentTarget?: EventTarget | null) {
+		// If not handled synchronously, MouseEvent.currentTarget becomes null. Allow callers to pass in currentTarget optionally to solve this.
+		let target = e.currentTarget ? e.currentTarget : currentTarget;
 
-		const rect = (e.currentTarget as HTMLElement).getBoundingClientRect();
+		console.log(target, currentTarget);
+
+		if (!data || !e || !target || !username) return false;
+
+		const rect = (target as HTMLElement).getBoundingClientRect();
 		data[ctx.platform].onShowViewerCard(username, 0, msgID, rect.bottom);
 		return true;
 	}

--- a/src/composable/chat/useFocusedChatters.ts
+++ b/src/composable/chat/useFocusedChatters.ts
@@ -1,0 +1,9 @@
+import { InjectionKey, Ref, inject } from "vue";
+
+export const FOCUSED_CHATTERS_KEY: InjectionKey<Ref<Array<string>>> = Symbol("seventv-focused-chatters");
+
+export function useFocusedChatters() {
+	const focusedChatters = inject(FOCUSED_CHATTERS_KEY);
+
+	return focusedChatters;
+}

--- a/src/site/twitch.tv/modules/chat/ChatList.vue
+++ b/src/site/twitch.tv/modules/chat/ChatList.vue
@@ -403,7 +403,6 @@ function handleClick(e: MouseEvent) {
 		if (clickedElement.parentNode) {
 			if (clickedElement.parentNode.parentNode) {
 				const parentOfParent = clickedElement.parentNode.parentNode as Element;
-				console.log(parentOfParent);
 				if (parentOfParent.classList.contains("seventv-chat-user-username")) {
 					return;
 				}

--- a/src/site/twitch.tv/modules/chat/ChatList.vue
+++ b/src/site/twitch.tv/modules/chat/ChatList.vue
@@ -24,7 +24,7 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, onMounted, onUnmounted, reactive, ref, toRef, watch } from "vue";
+import { nextTick, onMounted, onUnmounted, provide, reactive, ref, toRef, watch } from "vue";
 import { until, useDocumentVisibility, useMagicKeys, useTimeoutFn, watchDebounced } from "@vueuse/core";
 import { storeToRefs } from "pinia";
 import { useStore } from "@/store/main";
@@ -41,6 +41,7 @@ import { useChatHighlights } from "@/composable/chat/useChatHighlights";
 import { useChatMessages } from "@/composable/chat/useChatMessages";
 import { useChatProperties } from "@/composable/chat/useChatProperties";
 import { useChatScroller } from "@/composable/chat/useChatScroller";
+import { FOCUSED_CHATTERS_KEY } from "@/composable/chat/useFocusedChatters";
 import { useConfig } from "@/composable/useSettings";
 import { MessagePartType, MessageType, ModerationType } from "@/site/twitch.tv/";
 import ChatMessageUnhandled from "./ChatMessageUnhandled.vue";
@@ -77,7 +78,9 @@ const showRestrictedLowTrustUser = useConfig<boolean>("highlights.basic.restrict
 
 const messageHandler = toRef(props, "messageHandler");
 const list = toRef(props, "list");
-const focusedChatters = { ref: ref<Array<string>>([]) };
+const focusedChatters = ref<Array<string>>([]);
+
+provide(FOCUSED_CHATTERS_KEY, focusedChatters);
 
 // Unrender messages out of view
 const chatListEl = ref<HTMLElement>();
@@ -409,7 +412,7 @@ function handleClick(e: MouseEvent) {
 			}
 		}
 	}
-	focusedChatters.ref.value = [];
+	focusedChatters.value = [];
 }
 
 // Keep track of props

--- a/src/site/twitch.tv/modules/chat/ChatList.vue
+++ b/src/site/twitch.tv/modules/chat/ChatList.vue
@@ -7,12 +7,7 @@
 					v-bind="{ msg }"
 				>
 					<component :is="msg.instance" v-bind="msg.componentProps" :msg="msg">
-						<UserMessage
-							:msg="msg"
-							:emotes="emotes.active"
-							:chatters="messages.chattersByUsername"
-							:focusedChatters="focusedChatters.ref"
-						/>
+						<UserMessage :msg="msg" :emotes="emotes.active" :chatters="messages.chattersByUsername" />
 					</component>
 				</component>
 			</template>

--- a/src/site/twitch.tv/modules/chat/ChatModule.vue
+++ b/src/site/twitch.tv/modules/chat/ChatModule.vue
@@ -339,6 +339,12 @@ export const config = [
 		hint: "Show a 'Copy' icon when hovering over a chat message to copy the message",
 		defaultValue: true,
 	}),
+	declareConfig("chat.click_to_focus_on_chatter", "TOGGLE", {
+		path: ["Chat", "Message Tools"],
+		label: "Focus on Chatter",
+		hint: "Double click on a username in chat to focus on their messages, by dimming all others",
+		defaultValue: true,
+	}),
 	declareConfig<boolean>("highlights.basic.mention", "TOGGLE", {
 		path: ["Highlights", "Built-In"],
 		label: "Show Mention Highlights",

--- a/src/site/twitch.tv/modules/chat/components/message/UserMessage.vue
+++ b/src/site/twitch.tv/modules/chat/components/message/UserMessage.vue
@@ -266,7 +266,7 @@ function onUsernameDoubleClick() {
 	document.getSelection()?.empty();
 }
 
-let clickTimer: number = -1;
+let clickTimer = -1;
 function handleUsernameClick(ev: MouseEvent) {
 	if (clickToFocusOnChatterEnabled.value) {
 		const target = ev.currentTarget;

--- a/src/site/twitch.tv/modules/chat/components/message/UserMessage.vue
+++ b/src/site/twitch.tv/modules/chat/components/message/UserMessage.vue
@@ -7,7 +7,7 @@
 			deleted: !hideDeletionState && (msg.moderation.banned || msg.moderation.deleted),
 			'has-mention': as == 'Chat' && msg.mentions.has('#actor'),
 			'has-highlight': as == 'Chat' && msg.highlight,
-			'not-focused': focusedChatters.value.length != 0 && !isUserFocused(),
+			'not-focused': focusedChatters && focusedChatters.length != 0 && !isUserFocused(),
 		}"
 		:state="msg.deliveryState"
 		:style="{
@@ -99,6 +99,7 @@ import { useChannelContext } from "@/composable/channel/useChannelContext";
 import { useChatModeration } from "@/composable/chat/useChatModeration";
 import { useChatProperties } from "@/composable/chat/useChatProperties";
 import { useChatTools } from "@/composable/chat/useChatTools";
+import { useFocusedChatters } from "@/composable/chat/useFocusedChatters";
 import { useCosmetics } from "@/composable/useCosmetics";
 import { useConfig } from "@/composable/useSettings";
 import Emote from "@/site/twitch.tv/modules/chat/components/message/Emote.vue";
@@ -138,6 +139,7 @@ const ctx = useChannelContext();
 const properties = useChatProperties(ctx);
 const { openViewerCard } = useChatTools(ctx);
 const { pinChatMessage } = useChatModeration(ctx, msg.value.author?.username ?? "");
+const focusedChatters = useFocusedChatters();
 
 const emoteScale = useConfig<number>("chat.emote_scale");
 
@@ -256,11 +258,13 @@ watchEffect(() => {
 });
 
 function isUserFocused() {
-	return props.focusedChatters.value.includes(msg.value.author!.username);
+	if (!focusedChatters) return false;
+	return focusedChatters.value.includes(msg.value.author!.username);
 }
 
 function onUsernameDoubleClick() {
-	props.focusedChatters.value.push(msg.value.author!.username);
+	if (!focusedChatters) return;
+	focusedChatters.value.push(msg.value.author!.username);
 
 	// Clear blue selection after double clicking username
 	document.getSelection()?.empty();

--- a/src/site/twitch.tv/modules/chat/components/message/UserMessage.vue
+++ b/src/site/twitch.tv/modules/chat/components/message/UserMessage.vue
@@ -89,7 +89,7 @@
 </template>
 
 <script setup lang="ts">
-import { Ref, ref, toRef, watch, watchEffect } from "vue";
+import { ref, toRef, watch, watchEffect } from "vue";
 import { useTimeoutFn } from "@vueuse/shared";
 import { SetHexAlpha } from "@/common/Color";
 import { log } from "@/common/Logger";

--- a/src/site/twitch.tv/modules/chat/components/message/UserMessage.vue
+++ b/src/site/twitch.tv/modules/chat/components/message/UserMessage.vue
@@ -127,7 +127,6 @@ const props = withDefaults(
 		hideDeletionState?: boolean;
 		showButtons?: boolean;
 		forceTimestamp?: boolean;
-		focusedChatters: Ref<Array<string>>;
 	}>(),
 	{ as: "Chat" },
 );

--- a/src/site/twitch.tv/modules/chat/components/message/parts/Mention.vue
+++ b/src/site/twitch.tv/modules/chat/components/message/parts/Mention.vue
@@ -17,6 +17,7 @@
 import type { ChatMessage, MentionToken } from "@/common/chat/ChatMessage";
 import { useChannelContext } from "@/composable/channel/useChannelContext";
 import { useChatTools } from "@/composable/chat/useChatTools";
+import { useFocusedChatters } from "@/composable/chat/useFocusedChatters";
 import { useConfig } from "@/composable/useSettings";
 import UserTag from "../UserTag.vue";
 
@@ -25,12 +26,36 @@ const props = defineProps<{
 	msg: ChatMessage;
 }>();
 
+const clickToFocusOnChatterEnabled = useConfig<boolean>("chat.click_to_focus_on_chatter");
 const shouldRenderColoredMentions = useConfig("chat.colored_mentions");
 const ctx = useChannelContext();
 const tools = useChatTools(ctx);
+const focusedChatters = useFocusedChatters();
 
+function onUsernameDoubleClick() {
+	if (!focusedChatters) return;
+	focusedChatters.value.push(props.token.content.recipient);
+	// Clear blue selection after double clicking username
+	document.getSelection()?.empty();
+}
+
+let clickTimer = -1;
 function onClick(ev: MouseEvent) {
-	tools.openViewerCard(ev, props.token.content.recipient, props.msg.id);
+	if (clickToFocusOnChatterEnabled.value) {
+		const target = ev.currentTarget;
+		if (ev.detail === 1) {
+			clickTimer = setTimeout(() => {
+				// Single click
+				tools.openViewerCard(ev, props.token.content.recipient, props.msg.id, target);
+			}, 300);
+		} else if (ev.detail >= 2) {
+			// Double click
+			clearTimeout(clickTimer);
+			onUsernameDoubleClick();
+		}
+	} else {
+		tools.openViewerCard(ev, props.token.content.recipient, props.msg.id);
+	}
 }
 </script>
 


### PR DESCRIPTION
https://imgur.com/a/66m5PSQ

Added the ability to double click on a username in chat to dim all others, so you can easily see messages from that user. Also added setting to disable/enable.

I think it's planned to add a better user card that shows all of a user's messages, at which point this feature could be argued to be redundant, but I think it might still have a place as a more convenient way to quickly focus on a chatter for a few seconds to see if they respond to something, without needing to have the user card open on your screen. Idk, what do u think? 