### PR TITLE
[Bug Fix] React button overlap in hidden elements feature

### DIFF
--- a/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
+++ b/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
@@ -196,6 +196,10 @@ export const config = [
 	button[data-test-selector="unfollow-button"] {
 		display: none !important;
 	}
+	// Prevents "React" button from overlapping the notification / subscribe button
+	div[data-target="channel-header-right"] > div:first-child {
+		margin-right: -1rem !important;
+	}
 }
 
 .seventv-hide-live-notification-button {

--- a/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
+++ b/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
@@ -206,6 +206,15 @@ export const config = [
 	button[data-a-target="notifications-toggle"] {
 		display: none !important;
 	}
+	// Remove entire div containing live noti button to get rid of left padding
+	div[data-target="channel-header-right"]
+		> *:nth-child(2)
+		> *:nth-child(1)
+		> *:nth-child(2)
+		> *:nth-child(1)
+		> *:nth-child(2) {
+		display: none !important;
+	}
 }
 
 .seventv-hide-subscribe-button {


### PR DESCRIPTION
## Bug Fix 

Small bug fix if hiding "Unfollow" button without hiding "React" button.

This PR also adds another selector for removing the live notification button with the goal of removing the left padding to make the UI look cleaner after removal. However, the original selector is still added as a fallback option since the new selector relies on a chain of multiple children.

### Screenshots
Normal: 
![image](https://user-images.githubusercontent.com/69816894/235357283-4773d3cd-1386-4a0b-84cd-32e1bb742c13.png)

#### Before Fix:
With just unfollow hidden:
![image](https://user-images.githubusercontent.com/69816894/235357354-88f74c9d-cd74-4d01-b6a9-42941a1579c5.png)

With unfollow and live notification hidden:
![image](https://user-images.githubusercontent.com/69816894/235357395-5035b8e2-7d59-4851-b882-eca03accb930.png)

With just live notification hidden:
![image](https://user-images.githubusercontent.com/69816894/235357481-01de5e97-02c5-4e20-9749-7ed3beb1585d.png)

#### After Fix:
With just unfollow hidden:
![image](https://user-images.githubusercontent.com/69816894/235357991-fc9b8c62-1779-44a0-946e-af16b461fd71.png)

With unfollow and live notification hidden:
![image](https://user-images.githubusercontent.com/69816894/235357969-815a7f75-dc36-48de-9f2c-00d7bb73c88b.png)

With just live notification hidden: 
![image](https://user-images.githubusercontent.com/69816894/235358179-c9620159-a7df-4de7-847d-37de15df7254.png)
