### PR TITLE
[Bug Fix] Hide recommended channels when side bar is collapsed

### DIFF
--- a/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
+++ b/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
@@ -175,13 +175,15 @@ export const config = [
 }
 
 .seventv-hide-recommended-channels {
-	#side-nav > *:nth-child(1) > *:nth-child(1) > *:nth-child(3) {
+	div[data-a-target="side-nav-bar"] #side-nav > *:nth-child(1) > *:nth-child(1) > *:nth-child(3),
+	div[data-a-target="side-nav-bar-collapsed"] #side-nav > *:nth-child(1) > *:nth-child(1) > *:nth-child(2) {
 		display: none !important;
 	}
 }
 
 .seventv-hide-viewers-also-watch {
-	#side-nav > *:nth-child(1) > *:nth-child(1) > *:nth-child(4) {
+	div[data-a-target="side-nav-bar"] #side-nav > *:nth-child(1) > *:nth-child(1) > *:nth-child(4),
+	div[data-a-target="side-nav-bar-collapsed"] #side-nav > *:nth-child(1) > *:nth-child(1) > *:nth-child(3) {
 		display: none !important;
 	}
 }


### PR DESCRIPTION
## Bug Fix

Improved CSS selectors to hide the "recommended channels" and "X viewers also watch" when sidebar is collapsed or not collapsed.

Addresses Issue https://github.com/SevenTV/Extension/issues/556

![image](https://user-images.githubusercontent.com/69816894/235367832-38ecc17f-e0ec-4b57-a782-5d8c6cf38554.png)
![image](https://user-images.githubusercontent.com/69816894/235367854-13276b4a-af7d-4a01-8fcc-5e36f1af3b3b.png)
