### PR TITLE
feat/pause video on click

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -6,6 +6,7 @@
 -   Fixed tooltips of nametag paints appearing even if they are disabled
 -   Reinstated functionality on youtube.com
 -   Added a "Site Layout" menu where certain features of the Twitch website can be hidden
+-   Added ability to pause stream when clicking on the video player in Channel -> Video Player settings
 
 ### Version 3.0.6.1000
 

--- a/src/site/twitch.tv/modules/video-player/VideoPlayerModule.vue
+++ b/src/site/twitch.tv/modules/video-player/VideoPlayerModule.vue
@@ -16,19 +16,19 @@ const videoPlayerClickHandler = document.querySelector('div[data-a-target="playe
 const video = document.querySelector('div[data-a-target="video-player"] video') as HTMLMediaElement;
 
 function pauseOnClick(): void {
-    if (video && !video.paused) {
+	if (video && !video.paused) {
 		video.pause();
 	}
 }
 
 watchEffect(() => {
-    if (videoPlayerClickHandler) {
-        if (pauseOnClickEnabled.value) {
-            videoPlayerClickHandler.addEventListener("click", pauseOnClick);
-        } else {
-            videoPlayerClickHandler.removeEventListener("click", pauseOnClick);
-        }
-    }
+	if (videoPlayerClickHandler) {
+		if (pauseOnClickEnabled.value) {
+			videoPlayerClickHandler.addEventListener("click", pauseOnClick);
+		} else {
+			videoPlayerClickHandler.removeEventListener("click", pauseOnClick);
+		}
+	}
 });
 
 markAsReady();

--- a/src/site/twitch.tv/modules/video-player/VideoPlayerModule.vue
+++ b/src/site/twitch.tv/modules/video-player/VideoPlayerModule.vue
@@ -1,0 +1,49 @@
+<template />
+
+<script setup lang="ts">
+import { declareModule } from "@/composable/useModule";
+import { declareConfig, useConfig } from "@/composable/useSettings";
+import { watchEffect } from "vue";
+
+const { markAsReady } = declareModule("video-player", {
+	name: "Video Player",
+	depends_on: [],
+});
+
+const pauseOnClickEnabled = useConfig<boolean>("channel.video_player.pause_on_click");
+
+const videoPlayerClickHandler = document.querySelector('div[data-a-target="player-overlay-click-handler"]');
+const video = document.querySelector('div[data-a-target="video-player"] video') as HTMLMediaElement;
+
+function pauseOnClick(): void {
+    if (video && !video.paused) {
+		video.pause();
+	}
+}
+
+watchEffect(() => {
+    if (videoPlayerClickHandler) {
+        if (pauseOnClickEnabled.value) {
+            videoPlayerClickHandler.addEventListener("click", pauseOnClick);
+        } else {
+            videoPlayerClickHandler.removeEventListener("click", pauseOnClick);
+        }
+    }
+});
+
+markAsReady();
+</script>
+
+<script lang="ts">
+/**
+ * Settings configuration for video player
+ */
+export const config = [
+	declareConfig("channel.video_player.pause_on_click", "TOGGLE", {
+		path: ["Channel", "Video Player"],
+		label: "Pause Stream on Click",
+		hint: "If checked, the stream can be paused and unpaused by clicking the video player",
+		defaultValue: false,
+	}),
+];
+</script>

--- a/src/types/tw.module.d.ts
+++ b/src/types/tw.module.d.ts
@@ -9,6 +9,7 @@ import type HiddenElementsModuleVue from "@/site/twitch.tv/modules/hidden-elemen
 import type ModLogsModule from "@/site/twitch.tv/modules/mod-logs/ModLogsModule.vue";
 import type SettingsModuleVue from "@/site/twitch.tv/modules/settings/SettingsModule.vue";
 import type SidebarPreviewsModuleVue from "@/site/twitch.tv/modules/sidebar-previews/SidebarPreviewsModule.vue";
+import type VideoPlayerModuleVue from "@/site/twitch.tv/modules/video-player/VideoPlayerModule.vue";
 
 declare type TwModuleID = keyof TwModuleComponentMap;
 
@@ -20,6 +21,7 @@ declare type TwModuleComponentMap = {
 	"hidden-elements": typeof HiddenElementsModuleVue;
 	"mod-logs": typeof ModLogsModule;
 	"sidebar-previews": typeof SidebarPreviewsModuleVue;
+	"video-player": typeof VideoPlayerModuleVue;
 	autoclaim: typeof AutoclaimModuleVue;
 	avatars: typeof AvatarsModuleVue;
 	chat: typeof ChatModuleVue;


### PR DESCRIPTION
## Feature

Reference: https://github.com/SevenTV/Extension/issues/484

This PR adds a "VideoPlayerModule" and with this module the feature to pause the video player on click is added.
Event listener is added on page load or when the setting is enabled, and the event listener is removed when setting is disabled.
Setting is false by default.

![image](https://user-images.githubusercontent.com/69816894/235559262-9dbf7b13-9f7e-4a19-93df-91aed7e32416.png)

Added a sub category to "Channel" called "Video Player" for this setting. Would like feedback on if I should move to a different category or change the name at all. Possibly "General" instead of "Channel"?