### PR TITLE
Fix menu location bug

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -6,6 +6,7 @@
 -   Fixed tooltips of nametag paints appearing even if they are disabled
 -   Reinstated functionality on youtube.com
 -   Added a "Site Layout" menu where certain features of the Twitch website can be hidden
+-   Fixed a bug that caused the menu to occasionally appear at the top left
 
 ### Version 3.0.6.1000
 


### PR DESCRIPTION
Fixed the menu location by using a more reliable anchor, and ensured the inputElement updates after it's deleted and added back. When the user is timed out, both the anchorEl and the inputEl are removed from the site, which previously caused the anchor to glitch and the menu to appear at the top left.