### PR TITLE
fix: mozilla signing job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,10 +85,10 @@ jobs:
             - name: Build App
               env:
                   BRANCH: ${{ (inputs.branch == 'nightly' || env.IS_MASTER_COMMIT == 'true') && 'nightly' || inputs.branch == 'stable' && '' }}
-                  EXTENSION_ID: ${{ (inputs.branch == 'stable') && env.EXTENSION_ID_CWS || ((inputs.branch == 'nightly' || env.IS_MASTER_COMMIT == 'true') && env.NIGHTLY_EXTENSION_ID_CWS) }}
+                  EXTENSION_ID_MOZ: ${{ (inputs.branch == 'stable') && env.EXTENSION_ID_AMO || ((inputs.branch == 'nightly' || env.IS_MASTER_COMMIT == 'true') && env.NIGHTLY_EXTENSION_ID_AMO) }}
               run: |
                   OUT_DIR=mv3 yarn build:prod
-                  OUT_DIR=mv2 MOZILLA_ID=${{ env.EXTENSION_ID }} MV2=true yarn build:prod
+                  OUT_DIR=mv2 MOZILLA_ID=${{ env.EXTENSION_ID_MOZ }} MV2=true yarn build:prod
 
             - name: Create Build Archives
               run: |


### PR DESCRIPTION
This fixes a mistake where the extension ID in the generated manifest mismatched with the ID of the extension on AMO

Closes #543 