### PR TITLE
Add link to emote in emote card

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -4,6 +4,7 @@
 
 -   Enabled AVIF images on Firefox >= 113 by default
 -   Added sub duration & account creation date in the User Card
+-   Added a button to open an emote's full page from the emote card
 -   Fixed an issue where clicking the upper drag region in the User Card opened the user's channel
 
 ### Version 3.0.7.1000

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Improve your viewing experience on Twitch & YouTube with new features, emotes, vanity and performance.",
 	"private": true,
 	"version": "3.0.7",
-	"dev_version": "2.0",
+	"dev_version": "3.0",
 	"scripts": {
 		"start": "NODE_ENV=dev yarn build:dev && NODE_ENV=dev vite --mode dev",
 		"build:section:app": "vite build --config vite.config.ts",

--- a/src/assets/svg/icons/OpenLinkIcon.vue
+++ b/src/assets/svg/icons/OpenLinkIcon.vue
@@ -1,0 +1,9 @@
+/* Font Awesome Pro 6.4.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license
+(Commercial License) Copyright 2022 Fonticons, Inc. */
+<template>
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" fill="currentColor" width="1em" height="1em">
+		<path
+			d="M320 0c-17.7 0-32 14.3-32 32s14.3 32 32 32h82.7L201.4 265.4c-12.5 12.5-12.5 32.8 0 45.3s32.8 12.5 45.3 0L448 109.3V192c0 17.7 14.3 32 32 32s32-14.3 32-32V32c0-17.7-14.3-32-32-32H320zM80 32C35.8 32 0 67.8 0 112V432c0 44.2 35.8 80 80 80H400c44.2 0 80-35.8 80-80V320c0-17.7-14.3-32-32-32s-32 14.3-32 32V432c0 8.8-7.2 16-16 16H80c-8.8 0-16-7.2-16-16V112c0-8.8 7.2-16 16-16H192c17.7 0 32-14.3 32-32s-14.3-32-32-32H80z"
+		/>
+	</svg>
+</template>

--- a/src/site/global/components/EmoteCard.vue
+++ b/src/site/global/components/EmoteCard.vue
@@ -6,7 +6,14 @@
 			</div>
 			<div class="seventv-emote-card-display">
 				<div>
-					<h3 class="seventv-emote-card-title">{{ emote.name }}</h3>
+					<h3 class="seventv-emote-card-title">
+						<span>
+							{{ emote.name }}
+						</span>
+						<span v-if="emoteLink" class="seventv-emote-card-title-link">
+							<a :href="emoteLink" target="_blank"><OpenLinkIcon /></a>
+						</span>
+					</h3>
 					<p class="seventv-emote-card-subtitle">{{ subtitle }}</p>
 					<a v-if="owner.id" class="seventv-emote-card-user" :href="owner.url" target="_blank">
 						<img :src="owner.avatarURL" />
@@ -39,6 +46,7 @@ import { convertTwitchEmote } from "@/common/Transform";
 import { useApollo } from "@/composable/useApollo";
 import { userQuery } from "@/assets/gql/seventv.user.gql";
 import { emoteCardQuery } from "@/assets/gql/tw.emote-card.gql";
+import OpenLinkIcon from "@/assets/svg/icons/OpenLinkIcon.vue";
 import { useQuery } from "@vue/apollo-composable";
 
 const props = defineProps<{
@@ -52,6 +60,7 @@ const owner = reactive(emptyUser());
 const actor = reactive(emptyUser());
 const subtitle = ref("");
 const timestamp = ref("");
+const emoteLink = ref<string | null>(null);
 
 function emptyUser() {
 	return {
@@ -122,7 +131,9 @@ watchEffect(async () => {
 		);
 
 		timestamp.value = new Date(props.emote.timestamp ?? 0).toLocaleDateString();
-	}
+		emoteLink.value = `//7tv.app/emotes/${props.emote.id}`;
+	} else if (props.emote.provider === "BTTV") emoteLink.value = `//betterttv.com/emotes/${props.emote.id}`;
+	else if (props.emote.provider === "FFZ") emoteLink.value = `//frankerfacez.com/emoticon/${props.emote.id}`;
 });
 
 watch(
@@ -168,6 +179,16 @@ main.seventv-emote-card-container {
 				font-size: 2rem;
 				font-weight: 600;
 				color: var(--seventv-text-primary);
+			}
+		}
+
+		.seventv-emote-card-title {
+			display: flex;
+			align-items: baseline;
+			gap: 0.7rem;
+
+			.seventv-emote-card-title-link {
+				font-size: 1.25rem;
 			}
 		}
 


### PR DESCRIPTION
Add an icon with a link to open the emote in a new tab directly from the emote card.