### PR TITLE
feat: Enable AVIFs on Firefox >= v113 by default

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -2,7 +2,7 @@
 
 **The changes listed here are not assigned to an official release**.
 
-- No unreleased changes yet.
+-   Enable AVIF images on Firefox >= 113 by default
 
 ### Version 3.0.7.1000
 

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -2,7 +2,7 @@
 
 **The changes listed here are not assigned to an official release**.
 
--   Enable AVIF images on Firefox >= 113 by default
+-   Enabled AVIF images on Firefox >= 113 by default
 
 ### Version 3.0.7.1000
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Improve your viewing experience on Twitch & YouTube with new features, emotes, vanity and performance.",
 	"private": true,
 	"version": "3.0.7",
-	"dev_version": "1.0",
+	"dev_version": "2.0",
 	"scripts": {
 		"start": "NODE_ENV=dev yarn build:dev && NODE_ENV=dev vite --mode dev",
 		"build:section:app": "vite build --config vite.config.ts",

--- a/src/composable/useUserAgent.ts
+++ b/src/composable/useUserAgent.ts
@@ -13,7 +13,9 @@ const browser = agent.getBrowser();
 const data = reactive<UserAgentHelper>({
 	agent,
 	browser,
-	avif: browser.name === "Chrome" && parseInt(browser.version as string, 10) >= 100,
+	avif:
+		(browser.name === "Chrome" && parseInt(browser.version as string, 10) >= 100) ||
+		(browser.name === "Firefox" && parseInt(browser.version as string, 10) >= 113),
 	preferredFormat: "WEBP",
 });
 

--- a/src/store/main.ts
+++ b/src/store/main.ts
@@ -74,7 +74,10 @@ export const useStore = defineStore("main", {
 			return this.agent.getBrowser();
 		},
 		avifSupported(): boolean {
-			return this.browser.name === "Chrome" && parseInt(this.browser.version as string, 10) >= 100;
+			return (
+				(this.browser.name === "Chrome" && parseInt(this.browser.version as string, 10) >= 100) ||
+				(this.browser.name === "Firefox" && parseInt(this.browser.version as string, 10) >= 113)
+			);
 		},
 	},
 });


### PR DESCRIPTION
Firefox [has supported AVIF images for a while](https://www.mozilla.org/en-US/firefox/93.0/releasenotes/), but it didn't support animated sequences. As of Firefox 113, [animated sequences are enabled by default](https://www.mozilla.org/en-US/firefox/113.0/releasenotes/).