### PR TITLE
dependabot: ignore patch versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,7 +17,7 @@ updates:
       ignore:
         - dependency-name: "*"
           # Ignore patch versions
-          update-types: "version-update:semver-patch"
+          update-types: ["version-update:semver-patch"]
       labels:
         - "skip changelog check"
     # Fetch and update latest `github-actions` pkgs

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,10 @@ updates:
           prefix: fix
           prefix-development: chore
           include: scope
+      ignore:
+        - dependency-name: "*"
+          # Ignore patch versions
+          update-types: "version-update:semver-patch"
       labels:
         - "skip changelog check"
     # Fetch and update latest `github-actions` pkgs


### PR DESCRIPTION
Ignoring patch versions for dependabot notices to avoid flooding pull requests.