### PR TITLE
fix: UserCard content box overflow issue

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -6,7 +6,7 @@
 -   Added sub duration & account creation date in the User Card
 -   Added a button to open an emote's full page from the emote card
 -   Fixed an issue where clicking the upper drag region in the User Card opened the user's channel
--   Fixed UserCard content box overflow issue, when there is long text without spaces
+-   Fixed UserCard content overflowing due to long messages
 
 ### Version 3.0.7.1000
 

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -6,6 +6,7 @@
 -   Added sub duration & account creation date in the User Card
 -   Added a button to open an emote's full page from the emote card
 -   Fixed an issue where clicking the upper drag region in the User Card opened the user's channel
+-   Fixed UserCard content box overflow issue, when there is long text without spaces
 
 ### Version 3.0.7.1000
 

--- a/src/site/twitch.tv/modules/chat/components/user/UserCard.vue
+++ b/src/site/twitch.tv/modules/chat/components/user/UserCard.vue
@@ -671,6 +671,7 @@ main.seventv-user-card-container {
 	grid-template-rows: 0.5fr 2.5fr;
 	grid-auto-flow: row;
 	max-height: 26rem;
+	word-break: break-word;
 	grid-template-areas:
 		"tabs"
 		"messagelist";


### PR DESCRIPTION
When there is long text with no spaces, the UserCard box overflows. 

![v1-1](https://github.com/SevenTV/Extension/assets/35802638/34c26aa1-2b14-4322-87f6-dfbcc5db9f54) ![v1-2](https://github.com/SevenTV/Extension/assets/35802638/507ec1fc-2d00-4791-bc06-97709bb3d63e)

The problem was fixed with a minor CSS modification.

![new-v](https://github.com/SevenTV/Extension/assets/35802638/6a204987-5192-49a4-a623-ad495f87d0da)
