### PR TITLE
fix: chat scroller visible viewer list

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -6,7 +6,8 @@
 -   Added sub duration & account creation date in the User Card
 -   Added a button to open an emote's full page from the emote card
 -   Fixed an issue where clicking the upper drag region in the User Card opened the user's channel
--   Fixed UserCard content overflowing due to long messages
+-   Fixed user card content overflowing due to long messages
+-   Fixed chat scroller being visible in the viewer list
 
 ### Version 3.0.7.1000
 

--- a/src/site/twitch.tv/modules/chat/ChatController.vue
+++ b/src/site/twitch.tv/modules/chat/ChatController.vue
@@ -457,6 +457,7 @@ seventv-container.seventv-chat-list {
 }
 
 .seventv-chat-scroller {
+	z-index: 1;
 	height: 100%;
 }
 


### PR DESCRIPTION
Adding `z-index: 1;` to the chat scroller so that it can't spread into the layout change into Twitch UI

Closes #554 