### PR TITLE
fix: correct link to user profile in user-card

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -2,7 +2,7 @@
 
 **The changes listed here are not assigned to an official release**.
 
--   No unreleased changes yet.
+-   Fixed link to twitch user profile if we located in stream manager dashbaord
 
 ### Version 3.0.8.1000
 

--- a/src/app/chat/UserCard.vue
+++ b/src/app/chat/UserCard.vue
@@ -383,7 +383,7 @@ function openNativeCard(ev: MouseEvent): void {
 }
 
 function getProfileURL(): string {
-	return window.location.origin + "/" + props.target.username;
+	return "https://www.twitch.tv/" + props.target.username;
 }
 
 function formatDateToString(date?: string): string {


### PR DESCRIPTION
If we located in `Stream Manager` and opening user card, with origin we going to `dashboard.twitch.tv/{username}`, which is wrong link.

So, i hardcoded twitch url to correctly handle this.

I'm not sure does this component used by youtube, if yes tell me i'll add checks for site address in this function.