### PR TITLE
fix: channel sets resetting when a new tab joins

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -2,7 +2,7 @@
 
 **The changes listed here are not assigned to an official release**.
 
--   No unreleased changes yet.
+-   Fixed an issue which sometimes caused channel emote sets to disappear
 
 ### Version 3.0.8.1000
 

--- a/src/site/twitch.tv/modules/chat/ChatData.vue
+++ b/src/site/twitch.tv/modules/chat/ChatData.vue
@@ -22,15 +22,10 @@ const channelSets = useLiveQuery(
 	() =>
 		db.channels
 			.where("id")
-			.equals(ctx.id ?? "")
+			.equals(ctx.id)
 			.first()
 			.then((c) => c?.set_ids ?? []),
-	() => {
-		// reset the third-party emote providers
-		emotes.providers["7TV"] = {};
-		emotes.providers["FFZ"] = {};
-		emotes.providers["BTTV"] = {};
-	},
+	undefined,
 	{
 		reactives: [channelID],
 	},
@@ -46,6 +41,11 @@ useLiveQuery(
 			.equals("GLOBAL")
 			.sortBy("priority"),
 	(sets) => {
+		// reset the third-party emote providers
+		emotes.providers["7TV"] = {};
+		emotes.providers["FFZ"] = {};
+		emotes.providers["BTTV"] = {};
+
 		if (!sets) return;
 
 		for (const set of sets) {

--- a/src/worker/worker.events.ts
+++ b/src/worker/worker.events.ts
@@ -91,6 +91,7 @@ export class EventAPI {
 
 		this.sessionID = msg.data.session_id;
 		this.heartbeatInterval = msg.data.heartbeat_interval;
+		this.backoff = 100;
 
 		this.shouldResume = false;
 


### PR DESCRIPTION
This fixes an occasional issue when an IDB push occurs which led to the channel sets live query triggering, resetting data of emote providers and causing the channel sets on other tabs to be disabled.