### PR TITLE
hosted-deploy(fix): remove built-in stylesheet

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -4,6 +4,7 @@
 
 -   Added new feature: Paint Tool ([subscribers only](https://7tv.app/store))
 -   Fixed an issue which sometimes caused channel emote sets to disappear
+-   Fixed an issue which caused stylesheets to be duplicated when running in hosted mode
 
 ### Version 3.0.8.1000
 

--- a/src/site/site.app.ts
+++ b/src/site/site.app.ts
@@ -74,3 +74,14 @@ app.use(createPinia())
 	.directive("tooltip", TooltipDirective)
 	.directive("cosmetic-paint", TextPaintDirective)
 	.mount("#seventv-root");
+
+// unlink built-in stylesheet while in hosted mode
+if (seventv.remote) {
+	const sheets = document.querySelectorAll<HTMLLinkElement>("#seventv-stylesheet");
+	for (let i = 0; i < sheets.length; i++) {
+		const sheet = sheets.item(i);
+		if (!sheet || !sheet.href?.startsWith("chrome-extension")) continue;
+
+		sheet.remove();
+	}
+}


### PR DESCRIPTION
This fixes an issue where the extension's local stylesheet remained in place after the site script starts in hosted mode. This occasionally leads to style clashes where outdated local styles interfere with those in more recent hosted builds.