### PR TITLE
fix: emote menu broken due to twitch change

### DIFF
--- a/src/site/twitch.tv/modules/emote-menu/EmoteMenu.vue
+++ b/src/site/twitch.tv/modules/emote-menu/EmoteMenu.vue
@@ -97,9 +97,9 @@ function toggle(native?: boolean) {
 		t.props.closeEmotePicker();
 	} else {
 		t.props.clearMenus();
-		t.closeBitsCard();
-		t.closePaidPinnedChatCardForEmotePicker();
-		t.closeCheerCard();
+		if (typeof t.closeBitsCard === "function") t.closeBitsCard();
+		if (typeof t.closePaidPinnedChatCardForEmotePicker === "function") t.closePaidPinnedChatCardForEmotePicker();
+		if (typeof t.closeCheerCard === "function") t.closeCheerCard();
 	}
 
 	ctx.open = !ctx.open;


### PR DESCRIPTION
This fixes an issue causing the emote menu button on twitch to stop working as of a few minutes ago