### PR TITLE
site/kick(fix): historical messages

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -3,6 +3,7 @@
 **The changes listed here are not assigned to an official release**.
 
 - Tweaked some styling issues in the Emote Menu
+- Fixed an issue where historical messages did not consistently render on kick.com
 
 ### Version 3.0.9.1000
 

--- a/src/site/kick.com/modules/chat/ChatMessage.vue
+++ b/src/site/kick.com/modules/chat/ChatMessage.vue
@@ -24,7 +24,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, watch } from "vue";
+import { onMounted, watch, watchEffect } from "vue";
 import { ref } from "vue";
 import { onUnmounted } from "vue";
 import { useEventListener } from "@vueuse/core";
@@ -125,6 +125,7 @@ function process(): void {
 }
 
 watch(cosmetics, process);
+watchEffect(process);
 
 onMounted(process);
 

--- a/src/site/kick.com/modules/chat/ChatModule.vue
+++ b/src/site/kick.com/modules/chat/ChatModule.vue
@@ -85,7 +85,7 @@ onMounted(() => {
 });
 
 watch(() => router.currentRoute, handle, { immediate: true });
-useEventListener(document, "click", handle);
+useEventListener(document, "click", () => setTimeout(handle, 250));
 
 markAsReady();
 </script>


### PR DESCRIPTION
this adds a `watchEffect()` call on message to re-tokenize on prop changes, fixing inconsistent behavior when message history loads before emotes are available