### PR TITLE
site/kick(fix): message local tokens

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -2,9 +2,12 @@
 
 **The changes listed here are not assigned to an official release**.
 
+
 - Tweaked some styling issues in the Emote Menu
-- Fixed an issue where historical messages did not consistently render on kick.com
-- Fixed some issues where the connection flow with kick.com failed
+- Kick:
+  - Fixed an issue where historical messages did not consistently render
+  - Fixed some issues where the connection flow failed
+  - Fixed an issue which caused text to become misplaced when mixed with Kick native emotes
 
 ### Version 3.0.9.1000
 

--- a/src/site/kick.com/modules/chat/ChatMessage.vue
+++ b/src/site/kick.com/modules/chat/ChatMessage.vue
@@ -1,7 +1,7 @@
 <template>
 	<template v-for="(box, index) of containers" :key="index">
 		<Teleport :to="box">
-			<template v-for="(token, i) of tokens" :key="i">
+			<template v-for="(token, i) of tokens.get(box)" :key="i">
 				<span v-if="typeof token === 'string'"> {{ token }}</span>
 				<span v-else-if="IsEmoteToken(token)">
 					<Emote class="seventv-emote-token" :emote="token.content.emote" format="WEBP" />
@@ -24,7 +24,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, watch, watchEffect } from "vue";
+import { onMounted, reactive, watch, watchEffect } from "vue";
 import { ref } from "vue";
 import { onUnmounted } from "vue";
 import { useEventListener } from "@vueuse/core";
@@ -64,7 +64,7 @@ const cosmetics = useCosmetics(props.bind.authorID);
 const badgeContainer = document.createElement("seventv-container");
 
 const containers = ref<HTMLElement[]>([]);
-const tokens = ref<MessageTokenOrText[]>([]);
+const tokens = reactive<WeakMap<HTMLElement, MessageTokenOrText[]>>(new WeakMap());
 
 // Listen for click events
 useEventListener(props.bind.usernameEl.parentElement, "click", () => {
@@ -112,8 +112,6 @@ function process(): void {
 			result.push(after);
 		}
 
-		tokens.value = result;
-
 		const tokenEl = document.createElement("seventv-container");
 		tokenEl.classList.add("seventv-text-token");
 
@@ -121,6 +119,7 @@ function process(): void {
 		el.style.display = "none"; // to allow for graceful recovery, we only hide the original token
 
 		containers.value.push(tokenEl);
+		tokens.set(tokenEl, result);
 	}
 }
 


### PR DESCRIPTION
Addressing an oversight in the token reconstruction which failed to handle scenarios where multiple text fragments exist where non-text tokens are skipped. This adds a `WeakMap` to store tokens linked to the relevant containing element. This fixes an issue where all text tokens would be replaced with the last seen text fragment when mixed with native emotes