### PR TITLE
Add options to hide pinned hype chat list and hype chat button

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -4,6 +4,7 @@
 
 - Added an option to hide the new mature content dialogs on Twitch
 - Added formatting support for Hype Chat
+- Added options to hide Hype Chats and the Hype Chat button
 - Fixed an issue which prevented moderator data from loading in User Cards
 - Fixed an issue where nametags with blending paints did not correctly use the base color and appeared invisible instead
 - Kick:

--- a/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
+++ b/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
@@ -56,6 +56,12 @@ export const config = [
 		hint: "If checked, community highlights at the top of chat will be hidden (such as hype trains, pinned messages, drops, etc.)",
 		defaultValue: false,
 	}),
+	declareConfig("layout.hide_pinned_hype_chats", "TOGGLE", {
+		path: ["Site Layout", "Chat"],
+		label: "Hide Pinned Hype Chats",
+		hint: "If checked, the list of recent hype chats will be hidden",
+		defaultValue: false,
+	}),
 	// Main page elements (Twitch Features)
 	declareConfig("layout.hide_react_buttons", "TOGGLE", {
 		path: ["Site Layout", "Twitch Features"],
@@ -67,6 +73,12 @@ export const config = [
 		path: ["Site Layout", "Twitch Features"],
 		label: "Hide Bits Buttons",
 		hint: "If checked, the 'Bits' related buttons will be hidden",
+		defaultValue: false,
+	}),
+	declareConfig("layout.hide_hype_chat_button", "TOGGLE", {
+		path: ["Site Layout", "Twitch Features"],
+		label: "Hide Hype Chat Button",
+		hint: "If checked, the 'Hype Chat' related button will be hidden",
 		defaultValue: false,
 	}),
 	declareConfig("layout.hide_subscribe_button", "TOGGLE", {
@@ -156,6 +168,12 @@ export const config = [
 	}
 }
 
+.seventv-hide-hype-chat-button {
+	button[aria-label="Hype Chat"] {
+		display: none !important;
+	}
+}
+
 .seventv-hide-top-bar-of-stream {
 	div[class$="top-bar"] {
 		display: none !important;
@@ -170,6 +188,12 @@ export const config = [
 
 .seventv-hide-community-highlights {
 	div[class^="community-highlight-stack"] {
+		display: none !important;
+	}
+}
+
+.seventv-hide-pinned-hype-chats {
+	div[class$="paid-pinned-chat-message-list"] {
 		display: none !important;
 	}
 }

--- a/src/site/twitch.tv/modules/hidden-elements/hiddenElements.ts
+++ b/src/site/twitch.tv/modules/hidden-elements/hiddenElements.ts
@@ -6,8 +6,10 @@ const hideButtonsBelowChatbox = useConfig<boolean>("layout.hide_buttons_below_ch
 const hideStreamChatBar = useConfig<boolean>("layout.hide_stream_chat_bar");
 const hideReactButtons = useConfig<boolean>("layout.hide_react_buttons");
 const hideBitsButtons = useConfig<boolean>("layout.hide_bits_buttons");
+const hideHypeChatButton = useConfig<boolean>("layout.hide_hype_chat_button");
 const hideTopBarOfStream = useConfig<boolean>("layout.hide_top_bar_of_stream");
 const hidePlayerControls = useConfig<boolean>("layout.hide_player_controls");
+const hidePinnedHypeChats = useConfig<boolean>("layout.hide_pinned_hype_chats");
 const hideCommunityHighlights = useConfig<boolean>("layout.hide_community_highlights");
 const hideRecommendedChannels = useConfig<boolean>("layout.hide_recommended_channels");
 const hideViewersAlsoWatch = useConfig<boolean>("layout.hide_viewers_also_watch");
@@ -23,8 +25,10 @@ export const hiddenElementSettings: Array<{ class: string; isHidden: Ref<boolean
 	{ class: "seventv-hide-stream-chat-bar", isHidden: hideStreamChatBar },
 	{ class: "seventv-hide-react-buttons", isHidden: hideReactButtons },
 	{ class: "seventv-hide-bits-buttons", isHidden: hideBitsButtons },
+	{ class: "seventv-hide-hype-chat-button", isHidden: hideHypeChatButton },
 	{ class: "seventv-hide-top-bar-of-stream", isHidden: hideTopBarOfStream },
 	{ class: "seventv-hide-player-controls", isHidden: hidePlayerControls },
+	{ class: "seventv-hide-pinned-hype-chats", isHidden: hidePinnedHypeChats },
 	{ class: "seventv-hide-community-highlights", isHidden: hideCommunityHighlights },
 	{ class: "seventv-hide-recommended-channels", isHidden: hideRecommendedChannels },
 	{ class: "seventv-hide-viewers-also-watch", isHidden: hideViewersAlsoWatch },


### PR DESCRIPTION
# Feature: 2 new options to hide elements of the new Twitch feature called "Hype Chats"

## Purpose
Twitch just introduced the new feature "hype chats" (see: https://help.twitch.tv/s/article/hype-chat-faq).
This feature can be really annoying for casual viewers considering the bright colors and constant pin above the chat.
Therefore this PR aims to introduce options to remove most of the hype chat features.
However, this change does not affect the solid boxes of "hype chat"-messages in the chat.


## Implementation
Both options disable the respective site elements via their unique class or attribute. 
For the "Hype Chat"-button, the attribute "aria-label" is used as unique identification.
For the "Pinned list of hype chats", the element's class name proves unique.

Both new options have been tested in various combinations with other existing options and work flawlessly.

## The unchanged features on Twitch

The middle button (lightning icon) is the new "Hype Chat" button:
![Screenshot_486](https://github.com/SevenTV/Extension/assets/21990230/13f155ef-138c-4c4d-9985-5f2407478bea)
An example of a pinned "paid" hype chat:
![Screenshot_485](https://github.com/SevenTV/Extension/assets/21990230/62ca5caf-8637-48b2-bc70-c4a07b30c211)

## With the proposed options enabled (elements hidden)

"Hide Hype Chat Button"-toggle enabled:
![Screenshot_488](https://github.com/SevenTV/Extension/assets/21990230/985bbcb4-f544-4b1f-8fa4-ce49330a41ed)
"Hide Pinned Hype Chats"-toggle enabled:
![Screenshot_487](https://github.com/SevenTV/Extension/assets/21990230/6193f4bd-2943-4392-a138-e841a786a1e6)

## The options in the settings popup
![Screenshot_489](https://github.com/SevenTV/Extension/assets/21990230/4e5fda61-d8ee-4265-bc36-5efeea5759db)
![Screenshot_490](https://github.com/SevenTV/Extension/assets/21990230/8670d30d-62cf-4474-8957-dc5dcc563fba)

## Note
As this is my first time contributing to this extension/repo, please pardon any contributing errors of mine. I have used this extension for quite some time and would now love to help in its development. 
Feel free to adapt my changes to your desires or decline my PR completely.