### PR TITLE
worker(fix): eventapi initial connect failure

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -3,6 +3,7 @@
 **The changes listed here are not assigned to an official release**.
 
 - Fixed a user card crash
+- Fixed an issue with the EventAPI connection closing on the first initialization
 
 ### Version 3.0.13.1000
 

--- a/src/worker/index.ts
+++ b/src/worker/index.ts
@@ -138,7 +138,10 @@ export type EventAPIMessageData<O extends keyof typeof EventAPIOpCode> = {
 		code: number;
 		message: string;
 	};
-	ENDOFSTREAM: void;
+	ENDOFSTREAM: {
+		code: number;
+		message: string;
+	};
 	IDENTIFY: void;
 	RESUME: {
 		session_id: string;


### PR DESCRIPTION
This fixes a mistake causing the EventAPI connection to be closed with an `Already Subscribed` error due to the `syncSubscriptions()` method being called upon the initial connect.