### PR TITLE
twitch/chat(tweak): default msg batch 150->250

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -4,6 +4,7 @@
 
 - Fixed a user card crash
 - Fixed an issue with the EventAPI connection closing on the first initialization
+- Increased the default value for Message Batching from 150 to 250
 
 ### Version 3.0.13.1000
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Improve your viewing experience on Twitch & YouTube with new features, emotes, vanity and performance.",
 	"private": true,
 	"version": "3.0.13",
-	"dev_version": "1.0",
+	"dev_version": "2.0",
 	"scripts": {
 		"start": "NODE_ENV=dev yarn build:dev && NODE_ENV=dev vite --mode dev",
 		"build:section:app": "vite build --config vite.config.ts",

--- a/src/site/twitch.tv/modules/chat/ChatModule.vue
+++ b/src/site/twitch.tv/modules/chat/ChatModule.vue
@@ -205,7 +205,7 @@ export const config = [
 				[1000, 1000, "PowerPoint Presentation"],
 			],
 		},
-		defaultValue: 150,
+		defaultValue: 250,
 	}),
 	declareConfig<number>("chat.smooth_scroll_duration", "SLIDER", {
 		path: ["Chat", "Performance"],


### PR DESCRIPTION
This increases the default value for message batching on Twitch to be more inline with native chat