### PR TITLE
emote-menu(tweak): qol & shortcuts

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -2,6 +2,10 @@
 
 **The changes listed here are not assigned to an official release**.
 
+- Added a shortcut (Ctrl+E) to open the Emote Menu
+- Added shortcuts (Up/Down Arrows) to switch between providers in the Emote Menu
+- The input box in the Emote Menu is now focused automatically upon opening
+- Search in the Emote Menu will now automatically open the nearest tab where matches are found
 - Fixed a user card crash
 - Fixed an issue with the EventAPI connection closing on the first initialization
 - Fixed an issue that prevented new chatters from appearing in autocompletion

--- a/src/app/emote-menu/EmoteMenu.vue
+++ b/src/app/emote-menu/EmoteMenu.vue
@@ -125,7 +125,7 @@ const isCtrl = useKeyModifier("Control", { initial: false });
 onKeyStroke("e", (ev) => {
 	if (!isCtrl.value) return;
 
-	ctx.open = !ctx.open;
+	toggle();
 	ev.preventDefault();
 });
 

--- a/src/app/emote-menu/EmoteMenuSet.vue
+++ b/src/app/emote-menu/EmoteMenuSet.vue
@@ -1,5 +1,11 @@
 <template>
-	<div ref="containerEl" class="seventv-emote-set-container" :collapsed="collapsed" :ephemeral="ephemeral">
+	<div
+		v-if="ephemeral || emotes.length"
+		ref="containerEl"
+		class="seventv-emote-set-container"
+		:collapsed="collapsed"
+		:ephemeral="ephemeral"
+	>
 		<div class="seventv-set-header">
 			<div class="seventv-set-header-icon">
 				<img v-if="es.owner && es.owner.avatar_url" :src="es.owner.avatar_url" />

--- a/src/app/emote-menu/EmoteMenuTab.vue
+++ b/src/app/emote-menu/EmoteMenuTab.vue
@@ -113,7 +113,7 @@ const sets = emotes.byProvider(props.provider as SevenTV.Provider) ?? reactive({
 const store = useStore();
 const cosmetics = useCosmetics(store.identity?.id ?? "");
 const actor = useActor();
-const visibleSets = reactive<Set<SevenTV.EmoteSet>>(new Set());
+const visibleSets = reactive<Set<string>>(new Set());
 const sortedSets = ref([] as SevenTV.EmoteSet[]);
 const favorites = useConfig<Set<string>>("ui.emote_menu.favorites");
 // const usage = useConfig<Map<string, number>>("ui.emote_menu.usage");
@@ -139,9 +139,6 @@ const promotionPersonalSet: SevenTV.EmoteSet = {
 	emotes: [],
 };
 
-// "Most Used" is commented out pending refactor
-// Note the logic for favorites is also bad, though doesn't affect as many users
-
 function updateFavorites() {
 	if (!favorites.value) return [];
 
@@ -149,16 +146,6 @@ function updateFavorites() {
 		.map((eid) => emotes.find((ae) => ae.id === eid))
 		.filter((ae) => !!ae) as SevenTV.ActiveEmote[];
 }
-
-// function updateUsage() {
-// 	if (!shouldShowUsage.value) return [];
-//
-// 	return Array.from(usage.value.entries())
-// 		.sort((a, b) => b[1] - a[1])
-// 		.map((e) => emotes.find((ae) => ae.id === e[0]))
-// 		.filter((ae) => !!ae)
-// 		.slice(0, 50) as SevenTV.ActiveEmote[];
-// }
 
 if (props.provider === "FAVORITE") {
 	// create favorite set
@@ -168,19 +155,9 @@ if (props.provider === "FAVORITE") {
 		emotes: updateFavorites(),
 	} as SevenTV.EmoteSet));
 
-	// const usageSet = (sets["USAGE"] = reactive({
-	// 	id: "USAGE",
-	// 	name: t("emote_menu.most_used_set"),
-	// 	emotes: updateUsage(),
-	// } as SevenTV.EmoteSet));
-
 	watch(favorites, () => {
 		favSet.emotes = updateFavorites();
 	});
-
-	// watch([usage, shouldShowUsage], () => {
-	// 	usageSet.emotes = updateUsage();
-	// });
 }
 
 // Select an Emote Set to jump-scroll to
@@ -218,9 +195,9 @@ function sortFn(a: SevenTV.EmoteSet, b: SevenTV.EmoteSet) {
 
 function updateVisibility(es: SevenTV.EmoteSet, state: boolean): void {
 	if (state) {
-		visibleSets.add(es);
+		visibleSets.add(es.id);
 	} else {
-		visibleSets.delete(es);
+		visibleSets.delete(es.id);
 	}
 
 	emit("provider-visible", !!visibleSets.size);

--- a/src/site/twitch.tv/modules/emote-menu/EmoteMenu.vue
+++ b/src/site/twitch.tv/modules/emote-menu/EmoteMenu.vue
@@ -23,7 +23,6 @@
 
 <script setup lang="ts">
 import { nextTick, onMounted, onUnmounted, ref, watch, watchEffect } from "vue";
-import { onKeyStroke, useKeyModifier } from "@vueuse/core";
 import { log } from "@/common/Logger";
 import { HookedInstance } from "@/common/ReactHooks";
 import { defineFunctionHook, definePropertyHook, unsetPropertyHook } from "@/common/Reflection";
@@ -74,15 +73,6 @@ onMounted(() => {
 		},
 		1,
 	);
-});
-
-// Shortcut (ctrl+e)
-const isCtrl = useKeyModifier("Control", { initial: false });
-onKeyStroke("e", (ev) => {
-	if (!isCtrl.value) return;
-
-	toggle();
-	ev.preventDefault();
 });
 
 // Toggle the menu's visibility


### PR DESCRIPTION
Adding some QoL to the emote menu

- Arrow Up/Down to switch between providers
- Automatically focus the input box upon opening
- Allow shifting tab focus forward, rather than only backward, during search
- Reinstate Ctrl+E as a shortcut to open the menu
- 