### PR TITLE
twitch/chat(fix): emote tooltip squish

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -9,6 +9,7 @@
 - Fixed a user card crash
 - Fixed an issue with the EventAPI connection closing on the first initialization
 - Fixed an issue that prevented new chatters from appearing in autocompletion
+- Fixed an issue which squished tooltips when hovering an emote on the far right side of chat
 - Increased the default value for Message Batching from 150 to 250
 
 ### Version 3.0.13.1000

--- a/src/app/chat/EmoteTooltip.vue
+++ b/src/app/chat/EmoteTooltip.vue
@@ -136,6 +136,7 @@ if (props.emote.data?.owner?.style?.color) {
 
 <style scoped lang="scss">
 .seventv-tooltip {
+	width: max-content;
 	display: flex;
 	flex-direction: column;
 	align-items: center;


### PR DESCRIPTION
This fixes emote tooltips being squished when hovering on the far right side

Closes #560 

Pull request originally by @saliven at #612 