### PR TITLE
Refactor 7tv Settings Button and Hide Top Nav Buttons

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -15,8 +15,9 @@
 -   Fixed an issue which squished tooltips when hovering an emote on the far right side of chat
 -   Fixed an issue which hid historical messages on Kick
 -   Increased the default value for Message Batching from 150 to 250
--   Added an option to hide turbo button (when logged in)
--   Fixed css selector for hiding bits button in top nav menu
+-   Added component hook for top nav bar to toggle bits, prime, whispers, notifcations, and turbo buttons
+    -   update 7tv settings button to use hook
+    -   removed relevant css selectors for the same
 
 ### Version 3.0.13.1000
 

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -16,8 +16,8 @@
 -   Fixed an issue which hid historical messages on Kick
 -   Increased the default value for Message Batching from 150 to 250
 -   Added component hook for top nav bar to toggle bits, prime, whispers, notifcations, and turbo buttons
-    -   update 7tv settings button to use hook
-    -   removed relevant css selectors for the same
+    -   Updated 7TV settings button to use hook
+    -   Removed relevant css selectors in hidden elements module for the same
 
 ### Version 3.0.13.1000
 

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -15,6 +15,8 @@
 -   Fixed an issue which squished tooltips when hovering an emote on the far right side of chat
 -   Fixed an issue which hid historical messages on Kick
 -   Increased the default value for Message Batching from 150 to 250
+-   Added an option to hide turbo button (when logged in)
+-   Fixed css selector for hiding bits button in top nav menu
 
 ### Version 3.0.13.1000
 

--- a/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
+++ b/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
@@ -188,7 +188,7 @@ export const config = [
 
 .seventv-hide-bits-buttons {
 	button[data-a-target="bits-button"] {
-	// button[data-a-target="top-nav-get-bits-button"] {
+		// button[data-a-target="top-nav-get-bits-button"] {
 		display: none !important;
 	}
 }

--- a/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
+++ b/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
@@ -111,6 +111,18 @@ export const config = [
 		hint: "If checked, the 'Get Ad-Free' button on the top bar will be hidden",
 		defaultValue: false,
 	}),
+	declareConfig("layout.hide_site_notifications_button", "TOGGLE", {
+		path: ["Site Layout", "Twitch Features"],
+		label: "Hide Site Notifications Button",
+		hint: "If checked, the 'Site Notifications' button on the top bar will be hidden",
+		defaultValue: false,
+	}),
+	declareConfig("layout.hide_whispers_button", "TOGGLE", {
+		path: ["Site Layout", "Twitch Features"],
+		label: "Hide Whispers Button",
+		hint: "If checked, the 'Whispers' button on the top bar will be hidden",
+		defaultValue: false,
+	}),
 	// Side bar elements
 	declareConfig("layout.hide_recommended_channels", "TOGGLE", {
 		path: ["Site Layout", "Sidebar"],
@@ -175,8 +187,8 @@ export const config = [
 }
 
 .seventv-hide-bits-buttons {
-	button[data-a-target="bits-button"],
-	.top-nav__menu > div:last-child > div:nth-child(5) {
+	button[data-a-target="bits-button"] {
+	// button[data-a-target="top-nav-get-bits-button"] {
 		display: none !important;
 	}
 }
@@ -260,12 +272,6 @@ export const config = [
 	.video-player .extensions-dock__layout,
 	.video-player .extensions-notifications,
 	.video-player .extensions-video-overlay-size-container {
-		display: none !important;
-	}
-}
-
-.seventv-hide-turbo-button {
-	.top-nav__menu > div:last-child > div:nth-child(6) {
 		display: none !important;
 	}
 }

--- a/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
+++ b/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
@@ -105,6 +105,12 @@ export const config = [
 		hint: "If checked, the 'Turn notifications off/on' button under the stream will be hidden",
 		defaultValue: false,
 	}),
+	declareConfig("layout.hide_turbo_button", "TOGGLE", {
+		path: ["Site Layout", "Twitch Features"],
+		label: "Hide Turbo Button",
+		hint: "If checked, the 'Get Ad-Free' button on the top bar will be hidden",
+		defaultValue: false,
+	}),
 	// Side bar elements
 	declareConfig("layout.hide_recommended_channels", "TOGGLE", {
 		path: ["Site Layout", "Sidebar"],
@@ -141,6 +147,7 @@ export const config = [
 </script>
 
 <style lang="scss">
+/* stylelint-disable selector-class-pattern */
 .seventv-hide-leaderboard {
 	div[data-test-selector="channel-leaderboard-container"] {
 		display: none !important;
@@ -169,7 +176,7 @@ export const config = [
 
 .seventv-hide-bits-buttons {
 	button[data-a-target="bits-button"],
-	button[data-a-target="top-nav-get-bits-button"] {
+	.top-nav__menu > div:last-child div:has(button[data-a-target="top-nav-get-bits-button"]) {
 		display: none !important;
 	}
 }
@@ -248,7 +255,6 @@ export const config = [
 }
 
 .seventv-hide-player-ext {
-	/* stylelint-disable */
 	.video-player .extension-taskbar,
 	.video-player .extension-container,
 	.video-player .extensions-dock__layout,
@@ -256,6 +262,11 @@ export const config = [
 	.video-player .extensions-video-overlay-size-container {
 		display: none !important;
 	}
-	/* stylelint-enable */
+}
+
+.seventv-hide-turbo-button {
+	.top-nav__menu > div:last-child div:has(div[data-a-target="tw-core-button-label-text"]) {
+		display: none !important;
+	}
 }
 </style>

--- a/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
+++ b/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
@@ -159,7 +159,6 @@ export const config = [
 </script>
 
 <style lang="scss">
-/* stylelint-disable selector-class-pattern */
 .seventv-hide-leaderboard {
 	div[data-test-selector="channel-leaderboard-container"] {
 		display: none !important;
@@ -267,12 +266,17 @@ export const config = [
 }
 
 .seventv-hide-player-ext {
-	.video-player .extension-taskbar,
-	.video-player .extension-container,
-	.video-player .extensions-dock__layout,
-	.video-player .extensions-notifications,
-	.video-player .extensions-video-overlay-size-container {
-		display: none !important;
+	.video-player {
+		.extension-taskbar,
+		.extension-container,
+		.extensions-notifications,
+		.extensions-video-overlay-size-container {
+			display: none !important;
+		}
 	}
+}
+/* stylelint-disable-next-line selector-class-pattern */
+.seventv-hide-player-ext .video-player .extensions-dock__layout {
+	display: none !important;
 }
 </style>

--- a/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
+++ b/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
@@ -69,10 +69,10 @@ export const config = [
 		hint: "If checked, the 'React' buttons will be hidden",
 		defaultValue: false,
 	}),
-	declareConfig("layout.hide_bits_buttons", "TOGGLE", {
-		path: ["Site Layout", "Twitch Features"],
+	declareConfig("layout.hide_chat_bits_button", "TOGGLE", {
+		path: ["Site Layout", "Chat"],
 		label: "Hide Bits Buttons",
-		hint: "If checked, the 'Bits' related buttons will be hidden",
+		hint: "If checked, the 'Bits' button in the chatbox will be hidden",
 		defaultValue: false,
 	}),
 	declareConfig("layout.hide_hype_chat_button", "TOGGLE", {
@@ -121,6 +121,12 @@ export const config = [
 		path: ["Site Layout", "Twitch Features"],
 		label: "Hide Whispers Button",
 		hint: "If checked, the 'Whispers' button on the top bar will be hidden",
+		defaultValue: false,
+	}),
+	declareConfig("layout.hide_topnav_bits_button", "TOGGLE", {
+		path: ["Site Layout", "Twitch Features"],
+		label: "Hide Bits Button",
+		hint: "If checked, the 'Bits' button on the top bar will be hidden",
 		defaultValue: false,
 	}),
 	// Side bar elements
@@ -185,9 +191,8 @@ export const config = [
 	}
 }
 
-.seventv-hide-bits-buttons {
+.seventv-hide-chat-bits-button {
 	button[data-a-target="bits-button"] {
-		// button[data-a-target="top-nav-get-bits-button"] {
 		display: none !important;
 	}
 }

--- a/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
+++ b/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
@@ -176,7 +176,7 @@ export const config = [
 
 .seventv-hide-bits-buttons {
 	button[data-a-target="bits-button"],
-	.top-nav__menu > div:last-child div:has(button[data-a-target="top-nav-get-bits-button"]) {
+	.top-nav__menu > div:last-child > div:nth-child(5) {
 		display: none !important;
 	}
 }
@@ -265,7 +265,7 @@ export const config = [
 }
 
 .seventv-hide-turbo-button {
-	.top-nav__menu > div:last-child div:has(div[data-a-target="tw-core-button-label-text"]) {
+	.top-nav__menu > div:last-child > div:nth-child(6) {
 		display: none !important;
 	}
 }

--- a/src/site/twitch.tv/modules/hidden-elements/hiddenElements.ts
+++ b/src/site/twitch.tv/modules/hidden-elements/hiddenElements.ts
@@ -5,7 +5,7 @@ const hideLeaderboard = useConfig<boolean>("layout.hide_channel_leaderboard");
 const hideButtonsBelowChatbox = useConfig<boolean>("layout.hide_buttons_below_chatbox");
 const hideStreamChatBar = useConfig<boolean>("layout.hide_stream_chat_bar");
 const hideReactButtons = useConfig<boolean>("layout.hide_react_buttons");
-const hideBitsButtons = useConfig<boolean>("layout.hide_bits_buttons");
+const hideBitsButtons = useConfig<boolean>("layout.hide_bits_buttons"); // we keep this here for the bits button in chat input
 const hideHypeChatButton = useConfig<boolean>("layout.hide_hype_chat_button");
 const hideTopBarOfStream = useConfig<boolean>("layout.hide_top_bar_of_stream");
 const hidePlayerControls = useConfig<boolean>("layout.hide_player_controls");
@@ -13,8 +13,8 @@ const hidePinnedHypeChats = useConfig<boolean>("layout.hide_pinned_hype_chats");
 const hideCommunityHighlights = useConfig<boolean>("layout.hide_community_highlights");
 const hideRecommendedChannels = useConfig<boolean>("layout.hide_recommended_channels");
 const hideViewersAlsoWatch = useConfig<boolean>("layout.hide_viewers_also_watch");
-const hidePrimeOffers = useConfig<boolean>("layout.hide_prime_offers");
-const hideTurboButton = useConfig<boolean>("layout.hide_turbo_button");
+// const hidePrimeOffers = useConfig<boolean>("layout.hide_prime_offers");
+// const hideTurboButton = useConfig<boolean>("layout.hide_turbo_button");
 const hideUnfollowButton = useConfig<boolean>("layout.hide_unfollow_button");
 const hideLiveNotificationButton = useConfig<boolean>("layout.hide_live_notification_button");
 const hideSubscribeButton = useConfig<boolean>("layout.hide_subscribe_button");
@@ -34,9 +34,9 @@ export const hiddenElementSettings: Array<{ class: string; isHidden: Ref<boolean
 	{ class: "seventv-hide-community-highlights", isHidden: hideCommunityHighlights },
 	{ class: "seventv-hide-recommended-channels", isHidden: hideRecommendedChannels },
 	{ class: "seventv-hide-viewers-also-watch", isHidden: hideViewersAlsoWatch },
-	{ class: "seventv-hide-prime-offers", isHidden: hidePrimeOffers },
+	// { class: "seventv-hide-prime-offers", isHidden: hidePrimeOffers },
 	{ class: "seventv-hide-unfollow-button", isHidden: hideUnfollowButton },
-	{ class: "seventv-hide-turbo-button", isHidden: hideTurboButton },
+	// { class: "seventv-hide-turbo-button", isHidden: hideTurboButton },
 	{ class: "seventv-hide-live-notification-button", isHidden: hideLiveNotificationButton },
 	{ class: "seventv-hide-subscribe-button", isHidden: hideSubscribeButton },
 	{ class: "seventv-hide-chat-input-box", isHidden: hideChatInputBox },

--- a/src/site/twitch.tv/modules/hidden-elements/hiddenElements.ts
+++ b/src/site/twitch.tv/modules/hidden-elements/hiddenElements.ts
@@ -14,6 +14,7 @@ const hideCommunityHighlights = useConfig<boolean>("layout.hide_community_highli
 const hideRecommendedChannels = useConfig<boolean>("layout.hide_recommended_channels");
 const hideViewersAlsoWatch = useConfig<boolean>("layout.hide_viewers_also_watch");
 const hidePrimeOffers = useConfig<boolean>("layout.hide_prime_offers");
+const hideTurboButton = useConfig<boolean>("layout.hide_turbo_button");
 const hideUnfollowButton = useConfig<boolean>("layout.hide_unfollow_button");
 const hideLiveNotificationButton = useConfig<boolean>("layout.hide_live_notification_button");
 const hideSubscribeButton = useConfig<boolean>("layout.hide_subscribe_button");
@@ -35,6 +36,7 @@ export const hiddenElementSettings: Array<{ class: string; isHidden: Ref<boolean
 	{ class: "seventv-hide-viewers-also-watch", isHidden: hideViewersAlsoWatch },
 	{ class: "seventv-hide-prime-offers", isHidden: hidePrimeOffers },
 	{ class: "seventv-hide-unfollow-button", isHidden: hideUnfollowButton },
+	{ class: "seventv-hide-turbo-button", isHidden: hideTurboButton },
 	{ class: "seventv-hide-live-notification-button", isHidden: hideLiveNotificationButton },
 	{ class: "seventv-hide-subscribe-button", isHidden: hideSubscribeButton },
 	{ class: "seventv-hide-chat-input-box", isHidden: hideChatInputBox },

--- a/src/site/twitch.tv/modules/hidden-elements/hiddenElements.ts
+++ b/src/site/twitch.tv/modules/hidden-elements/hiddenElements.ts
@@ -5,7 +5,7 @@ const hideLeaderboard = useConfig<boolean>("layout.hide_channel_leaderboard");
 const hideButtonsBelowChatbox = useConfig<boolean>("layout.hide_buttons_below_chatbox");
 const hideStreamChatBar = useConfig<boolean>("layout.hide_stream_chat_bar");
 const hideReactButtons = useConfig<boolean>("layout.hide_react_buttons");
-const hideBitsButtons = useConfig<boolean>("layout.hide_bits_buttons"); // we keep this here for the bits button in chat input
+const hideChatBitsButton = useConfig<boolean>("layout.hide_chat_bits_button");
 const hideHypeChatButton = useConfig<boolean>("layout.hide_hype_chat_button");
 const hideTopBarOfStream = useConfig<boolean>("layout.hide_top_bar_of_stream");
 const hidePlayerControls = useConfig<boolean>("layout.hide_player_controls");
@@ -26,7 +26,7 @@ export const hiddenElementSettings: Array<{ class: string; isHidden: Ref<boolean
 	{ class: "seventv-hide-buttons-below-chatbox", isHidden: hideButtonsBelowChatbox },
 	{ class: "seventv-hide-stream-chat-bar", isHidden: hideStreamChatBar },
 	{ class: "seventv-hide-react-buttons", isHidden: hideReactButtons },
-	{ class: "seventv-hide-bits-buttons", isHidden: hideBitsButtons },
+	{ class: "seventv-hide-chat-bits-button", isHidden: hideChatBitsButton },
 	{ class: "seventv-hide-hype-chat-button", isHidden: hideHypeChatButton },
 	{ class: "seventv-hide-top-bar-of-stream", isHidden: hideTopBarOfStream },
 	{ class: "seventv-hide-player-controls", isHidden: hidePlayerControls },

--- a/src/site/twitch.tv/modules/settings/SettingsMenuButton.vue
+++ b/src/site/twitch.tv/modules/settings/SettingsMenuButton.vue
@@ -23,7 +23,7 @@ const emit = defineEmits<{
 }>();
 
 const props = defineProps<{
-	inst: HookedInstance<Twitch.TopNavBarComponent> | undefined;
+	inst: HookedInstance<Twitch.TopNavBarComponent>;
 }>();
 
 const hideBitsButton = useConfig<boolean>("layout.hide_bits_buttons");

--- a/src/site/twitch.tv/modules/settings/SettingsMenuButton.vue
+++ b/src/site/twitch.tv/modules/settings/SettingsMenuButton.vue
@@ -12,18 +12,18 @@
 
 <script setup lang="ts">
 import { ref, toRaw, watch, watchEffect } from "vue";
+import { HookedInstance } from "@/common/ReactHooks";
+import { defineFunctionHook } from "@/common/Reflection";
+import { useConfig } from "@/composable/useSettings";
 import useUpdater from "@/composable/useUpdater";
 import Logo7TV from "@/assets/svg/logos/Logo7TV.vue";
-import { HookedInstance } from "@/common/ReactHooks";
-import { useConfig } from "@/composable/useSettings";
-import { defineFunctionHook } from "@/common/Reflection";
 
 const emit = defineEmits<{
 	(event: "toggle"): void;
 }>();
 
 const props = defineProps<{
-	inst: HookedInstance<Twitch.TopNavBarComponent>|undefined;
+	inst: HookedInstance<Twitch.TopNavBarComponent> | undefined;
 }>();
 
 const hideBitsButton = useConfig<boolean>("layout.hide_bits_buttons");
@@ -32,35 +32,59 @@ const hidePrimeCrown = useConfig<boolean>("layout.hide_prime_offers");
 const hideTurboButton = useConfig<boolean>("layout.hide_turbo_button");
 const hideWhispersButton = useConfig<boolean>("layout.hide_whispers_button");
 
-watch(hideBitsButton, (v) => {
-	createFunctionHook(v, "renderBitsButton");
-	rerenderTopNav();
-}, {immediate: true});
+watch(
+	hideBitsButton,
+	(v) => {
+		if (!props.inst?.component) return;
+		createFunctionHook(props.inst.component, "renderBitsButton", v);
+		rerenderTopNav();
+	},
+	{ immediate: true },
+);
 
-watch(hideSiteNotificationsButton, (v) => {
-	createFunctionHook(v, "renderOnsiteNotifications");
-	rerenderTopNav();
-}, {immediate: true});
+watch(
+	hideSiteNotificationsButton,
+	(v) => {
+		if (!props.inst?.component) return;
+		createFunctionHook(props.inst.component, "renderOnsiteNotifications", v);
+		rerenderTopNav();
+	},
+	{ immediate: true },
+);
 
-watch(hideTurboButton, (v) => {
-	createFunctionHook(v, "renderTurboButton");
-	rerenderTopNav();
-}, {immediate: true});
+watch(
+	hideTurboButton,
+	(v) => {
+		if (!props.inst?.component) return;
+		createFunctionHook(props.inst.component, "renderTurboButton", v);
+		rerenderTopNav();
+	},
+	{ immediate: true },
+);
 
-watch(hidePrimeCrown, (v) => {
-	createFunctionHook(v, "renderTwitchPrimeCrown");
-	rerenderTopNav();
-}, {immediate: true});
+watch(
+	hidePrimeCrown,
+	(v) => {
+		if (!props.inst?.component) return;
+		createFunctionHook(props.inst.component, "renderTwitchPrimeCrown", v);
+		rerenderTopNav();
+	},
+	{ immediate: true },
+);
 
-watch(hideWhispersButton, (v) => {
-	createFunctionHook(v, "renderWhispers");
-	rerenderTopNav();
-}, {immediate: true});
+watch(
+	hideWhispersButton,
+	(v) => {
+		if (!props.inst?.component) return;
+		createFunctionHook(props.inst.component, "renderWhispers", v);
+		rerenderTopNav();
+	},
+	{ immediate: true },
+);
 
-function createFunctionHook(state: boolean, funcName: any) {
-	if (!props.inst?.component) return;
-	defineFunctionHook(props.inst.component, funcName, function (old, ...args: unknown[]) {
-		return (state) ? null : old?.apply(this, args);
+function createFunctionHook<C extends object>(prop: C, funcName: keyof C, state: boolean) {
+	defineFunctionHook(prop, funcName, function (old, ...args: unknown[]) {
+		return state ? null : old?.apply(this, args);
 	});
 }
 
@@ -86,7 +110,6 @@ function insert7tvButton() {
 	} else {
 		navmenu.insertBefore(containerEl.value, navmenu.lastChild);
 	}
-
 }
 
 watchEffect(() => {

--- a/src/site/twitch.tv/modules/settings/SettingsMenuButton.vue
+++ b/src/site/twitch.tv/modules/settings/SettingsMenuButton.vue
@@ -32,7 +32,7 @@ defineExpose({
 	render7TVButton,
 });
 
-const hideBitsButton = useConfig<boolean>("layout.hide_bits_buttons");
+const hideBitsButton = useConfig<boolean>("layout.hide_topnav_bits_button");
 const hideSiteNotificationsButton = useConfig<boolean>("layout.hide_site_notifications_button");
 const hidePrimeCrown = useConfig<boolean>("layout.hide_prime_offers");
 const hideTurboButton = useConfig<boolean>("layout.hide_turbo_button");

--- a/src/site/twitch.tv/modules/settings/SettingsModule.vue
+++ b/src/site/twitch.tv/modules/settings/SettingsModule.vue
@@ -3,7 +3,9 @@
 		<SettingsMenu v-if="ctx.open" />
 	</Transition>
 
-	<SettingsMenuButton :inst="topnav.instances[0] ?? undefined" @toggle="ctx.open = !ctx.open" />
+	<template v-for="inst of topnav.instances" :key="inst.identifier">
+		<SettingsMenuButton :inst="inst" @toggle="ctx.open = !ctx.open" />
+	</template>
 </template>
 
 <script setup lang="ts">

--- a/src/site/twitch.tv/modules/settings/SettingsModule.vue
+++ b/src/site/twitch.tv/modules/settings/SettingsModule.vue
@@ -3,7 +3,7 @@
 		<SettingsMenu v-if="ctx.open" />
 	</Transition>
 
-	<SettingsMenuButton @toggle="ctx.open = !ctx.open" :inst="topnav.instances[0] ?? undefined" />
+	<SettingsMenuButton :inst="topnav.instances[0] ?? undefined" @toggle="ctx.open = !ctx.open" />
 </template>
 
 <script setup lang="ts">
@@ -22,13 +22,15 @@ const { markAsReady } = declareModule("settings", {
 const ctx = useSettingsMenu();
 
 // hook for the top nav bar
-const topnav = useComponentHook<Twitch.TopNavBarComponent>({
-	predicate: (n) => n.props && n.props.isWhispersLoaded && n.props.languageCode,
-	maxDepth: 100
-},
-{
-	trackRoot: true
-});
+const topnav = useComponentHook<Twitch.TopNavBarComponent>(
+	{
+		predicate: (n) => n.props && n.props.isWhispersLoaded && n.props.languageCode,
+		maxDepth: 100,
+	},
+	{
+		trackRoot: true,
+	},
+);
 
 markAsReady();
 </script>

--- a/src/site/twitch.tv/modules/settings/SettingsModule.vue
+++ b/src/site/twitch.tv/modules/settings/SettingsModule.vue
@@ -3,9 +3,7 @@
 		<SettingsMenu v-if="ctx.open" />
 	</Transition>
 
-	<template v-for="inst of topnav.instances" :key="inst.identifier">
-		<SettingsMenuButton :inst="inst" @toggle="ctx.open = !ctx.open" />
-	</template>
+	<SettingsMenuButton :inst="topnav.instances[0] ?? undefined" @toggle="ctx.open = !ctx.open" />
 </template>
 
 <script setup lang="ts">

--- a/src/site/twitch.tv/modules/settings/SettingsModule.vue
+++ b/src/site/twitch.tv/modules/settings/SettingsModule.vue
@@ -3,7 +3,11 @@
 		<SettingsMenu v-if="ctx.open" />
 	</Transition>
 
-	<SettingsMenuButton :inst="topnav.instances[0] ?? undefined" @toggle="ctx.open = !ctx.open" />
+	<SettingsMenuButton
+		ref="settingsMenuButton"
+		:inst="topnav.instances[0] ?? undefined"
+		@toggle="ctx.open = !ctx.open"
+	/>
 </template>
 
 <script setup lang="ts">
@@ -13,6 +17,7 @@ import SettingsMenuButton from "./SettingsMenuButton.vue";
 import SettingsMenu from "../../../../app/settings/SettingsMenu.vue";
 import { declareConfig } from "@/composable/useSettings";
 import { useComponentHook } from "@/common/ReactHooks";
+import { ref } from "vue";
 
 const { markAsReady } = declareModule("settings", {
 	name: "Settings",
@@ -20,6 +25,8 @@ const { markAsReady } = declareModule("settings", {
 });
 
 const ctx = useSettingsMenu();
+
+const settingsMenuButton = ref<InstanceType<typeof SettingsMenuButton> | null>(null);
 
 // hook for the top nav bar
 const topnav = useComponentHook<Twitch.TopNavBarComponent>(
@@ -29,6 +36,13 @@ const topnav = useComponentHook<Twitch.TopNavBarComponent>(
 	},
 	{
 		trackRoot: true,
+		hooks: {
+			update(inst) {
+				if (settingsMenuButton.value) {
+					settingsMenuButton.value.render7TVButton();
+				}
+			},
+		},
 	},
 );
 

--- a/src/site/twitch.tv/modules/settings/SettingsModule.vue
+++ b/src/site/twitch.tv/modules/settings/SettingsModule.vue
@@ -3,7 +3,7 @@
 		<SettingsMenu v-if="ctx.open" />
 	</Transition>
 
-	<SettingsMenuButton @toggle="ctx.open = !ctx.open" />
+	<SettingsMenuButton @toggle="ctx.open = !ctx.open" :inst="topnav.instances[0] ?? undefined" />
 </template>
 
 <script setup lang="ts">
@@ -12,6 +12,7 @@ import { useSettingsMenu } from "@/app/settings/Settings";
 import SettingsMenuButton from "./SettingsMenuButton.vue";
 import SettingsMenu from "../../../../app/settings/SettingsMenu.vue";
 import { declareConfig } from "@/composable/useSettings";
+import { useComponentHook } from "@/common/ReactHooks";
 
 const { markAsReady } = declareModule("settings", {
 	name: "Settings",
@@ -19,6 +20,15 @@ const { markAsReady } = declareModule("settings", {
 });
 
 const ctx = useSettingsMenu();
+
+// hook for the top nav bar
+const topnav = useComponentHook<Twitch.TopNavBarComponent>({
+	predicate: (n) => n.props && n.props.isWhispersLoaded && n.props.languageCode,
+	maxDepth: 100
+},
+{
+	trackRoot: true
+});
 
 markAsReady();
 </script>

--- a/src/types/twitch.d.ts
+++ b/src/types/twitch.d.ts
@@ -868,4 +868,16 @@ declare module Twitch {
 		name: string;
 		width: number;
 	}
+
+	export type TopNavBarComponent = ReactExtended.WritableComponent<{
+		isInspecting: boolean;
+		isWhispersLoaded: boolean;
+		languageCode: string;
+	}> & {
+		renderBitsButton: () => void;
+		renderOnsiteNotifications: () => void;
+		renderTurboButton: () => void;
+		renderTwitchPrimeCrown: () => void;
+		renderWhispers: () => void;
+	};
 }


### PR DESCRIPTION
As the title implies, adds an option to hide the Turbo Button in the top nav menu.

Additionally, switch the bits button selector to make the spacing cleaner when hidden