### PR TITLE
Choose Default Emote Menu Tab

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -2,6 +2,7 @@
 
 **The changes listed here are not assigned to an official release**.
 
+-   Added an option to select default Emote Menu tab
 -   Added a shortcut (Ctrl+E) to open the Emote Menu
 -   Added shortcuts (Up/Down Arrows) to switch between providers in the Emote Menu
 -   Search in the Emote Menu will now automatically open the nearest tab where matches are found

--- a/src/app/emote-menu/EmoteMenu.vue
+++ b/src/app/emote-menu/EmoteMenu.vue
@@ -99,8 +99,9 @@ const { providers, platform } = useStore();
 const searchInputRef = ref<HTMLInputElement | undefined>();
 
 const isSearchInputEnabled = useConfig<boolean>("ui.emote_menu_search");
+const defaultTab = useConfig<EmoteMenuTabName>("ui.emote_menu.default_tab");
 
-const activeProvider = ref<EmoteMenuTabName | null>("7TV");
+const activeProvider = ref<EmoteMenuTabName | null>(defaultTab.value);
 const visibleProviders = reactive<Record<EmoteMenuTabName, boolean>>({
 	FAVORITE: true,
 	"7TV": providers.has("7TV"),

--- a/src/app/emote-menu/EmoteMenu.vue
+++ b/src/app/emote-menu/EmoteMenu.vue
@@ -99,7 +99,7 @@ const { providers, platform } = useStore();
 const searchInputRef = ref<HTMLInputElement | undefined>();
 
 const isSearchInputEnabled = useConfig<boolean>("ui.emote_menu_search");
-const defaultTab = useConfig<EmoteMenuTabName>("ui.emote_menu.default_tab");
+const defaultTab = useConfig<EmoteMenuTabName>("ui.emote_menu.default_tab", "7TV");
 
 const activeProvider = ref<EmoteMenuTabName | null>(defaultTab.value);
 const visibleProviders = reactive<Record<EmoteMenuTabName, boolean>>({

--- a/src/site/twitch.tv/modules/emote-menu/EmoteMenuModule.vue
+++ b/src/site/twitch.tv/modules/emote-menu/EmoteMenuModule.vue
@@ -76,6 +76,20 @@ markAsReady();
 
 <script lang="ts">
 export const config = [
+	declareConfig("ui.emote_menu.default_tab", "DROPDOWN", {
+		path: ["Appearance", "Interface"],
+		label: "Emote Menu: Default Emote Tab",
+		hint: "Select default tab when opening emote menu",
+		options: [
+			["Favorite", "FAVORITE"],
+			["7TV", "7TV"],
+			["FFZ", "FFZ"],
+			["BTTV", "BTTV"],
+			["Platform", "PLATFORM"],
+			["Emoji", "EMOJI"],
+		],
+		defaultValue: "7TV",
+	}),
 	declareConfig("ui.emote_menu_search", "TOGGLE", {
 		path: ["Appearance", "Interface"],
 		label: "Emote Menu: Live Input Search",


### PR DESCRIPTION
Closes #670 

Added setting to choose the default emote menu tab on initial open.

Default value for setting is the same as the original hard-coded value.