### PR TITLE
fix: UserCard "hidden subscription status" message

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -5,6 +5,7 @@
 -   Added an option to select alternating background color for chat messages
 -   Fixed an issue with tab auto-completion on Kick
 -   Fixed emote tile width in emote menu
+-   Fixed "hidden subscription status" message in the User Card
 
 ### 3.0.15.1000
 

--- a/locale/en_US.yaml
+++ b/locale/en_US.yaml
@@ -19,6 +19,7 @@ user_card:
     subscription_tier: Tier {tier}
     subscription_length: Subscribed for {length} months
     previously_subscription_length: Previously subscribed for {length} months
+    hidden_subscription_status: Status hidden
     native: Open Native User Card
     no_messages: "{user} has not chatted here"
     no_timeouts: "{user} hasn't been timed out before"

--- a/src/app/chat/UserCard.vue
+++ b/src/app/chat/UserCard.vue
@@ -52,10 +52,14 @@
 						<p v-if="data.targetUser.relationship.subscription.isSubscribed">
 							<StarIcon />
 							{{
-								`${t("user_card.subscription_tier", {
-									tier: data.targetUser.relationship.subscription.tier[0],
-								})} -
-							${t("user_card.subscription_length", { length: data.targetUser.relationship.subscription.months })}`
+								data.targetUser.relationship.subscription.months
+									? `${t("user_card.subscription_tier", {
+											tier: data.targetUser.relationship.subscription.tier[0],
+									  })} -
+									  ${t("user_card.subscription_length", {
+											length: data.targetUser.relationship.subscription.months,
+										})}`
+									: `${t("user_card.hidden_subscription_status")}`
 							}}
 						</p>
 


### PR DESCRIPTION
The issue occurs when the "Hide Subscription Status in Chat Viewer Card" option is enabled in Twitch settings.

It says "Tier 1 - Subscribed for 0 months" no matter how long or which tier you have subscribed.

Before: 
![before](https://github.com/SevenTV/Extension/assets/35802638/582fa934-0be5-4bd9-9743-7e3ba9cb9706)

After: 
![after](https://github.com/SevenTV/Extension/assets/35802638/193614a2-6a65-45b0-8dc4-6ba28f30bc52)

This gives more accurate information about the subscription status.


