### PR TITLE
feat: Add check for favorite emotes and display helpful message

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -3,6 +3,7 @@
 **The changes listed here are not assigned to an official release**.
 
 -   Added an option to select alternating background color for chat messages
+-   Added a tip to the favorite menu to help users favorite emotes if none are found
 -   Fixed an issue with tab auto-completion on Kick
 -   Fixed emote tile width in emote menu
 -   Fixed "hidden subscription status" message in the User Card

--- a/locale/en_US.yaml
+++ b/locale/en_US.yaml
@@ -38,9 +38,9 @@ emote_menu:
     favorite_set: Favorite Emotes
     most_used_set: Most Used Emotes
     favorite_emotes_promo_1: You don't have any Favorite Emotes yet
-    favorite_emotes_promo_2: Tip hold ALT and click an emote to add it to your favorites
-    personal_emotes_promo_1: You don't have Personal Emotes yet
-    personal_emotes_promo_2: Use custom emotes anywhere on {PLATFORM} with a 7TV Subscription
+    favorite_emotes_promo_2: Hold {HOTKEY} and click an emote to add it to your favorites
+    personal_emotes_hint_1: You don't have Personal Emotes yet
+    personal_emotes_hint_2: Use custom emotes anywhere on {PLATFORM} with a 7TV Subscription
     sets:
         Channel Emotes: Channel Emotes
         Personal Emotes: Personal Emotes

--- a/locale/en_US.yaml
+++ b/locale/en_US.yaml
@@ -37,6 +37,8 @@ emote_menu:
     native: Open Native Menu
     favorite_set: Favorite Emotes
     most_used_set: Most Used Emotes
+    favorite_emotes_promo_1: You don't have any Favorite Emotes yet
+    favorite_emotes_promo_2: Tip hold ALT and click an emote to add it to your favorites
     personal_emotes_promo_1: You don't have Personal Emotes yet
     personal_emotes_promo_2: Use custom emotes anywhere on {PLATFORM} with a 7TV Subscription
     sets:

--- a/src/app/emote-menu/EmoteMenuTab.vue
+++ b/src/app/emote-menu/EmoteMenuTab.vue
@@ -27,6 +27,15 @@
 				</EmoteMenuSet>
 			</template>
 
+			<template v-if="provider === 'FAVORITE' && !hasFavoriteEmotes()">
+				<div class="seventv-promotion-personal-emotes">
+					<div>
+						<p v-t="'emote_menu.favorite_emotes_promo_1'" />
+						<span v-t="'emote_menu.favorite_emotes_promo_2'" />
+					</div>
+				</div>
+			</template>
+
 			<template v-for="es of sortedSets" :key="es.id">
 				<EmoteMenuSet
 					v-if="es.emotes.length"
@@ -158,6 +167,10 @@ if (props.provider === "FAVORITE") {
 	watch(favorites, () => {
 		favSet.emotes = updateFavorites();
 	});
+}
+
+function hasFavoriteEmotes() {
+	return props.provider === "FAVORITE" && sets["FAVORITE"].emotes.length > 0;
 }
 
 // Select an Emote Set to jump-scroll to

--- a/src/app/emote-menu/EmoteMenuTab.vue
+++ b/src/app/emote-menu/EmoteMenuTab.vue
@@ -30,8 +30,12 @@
 			<template v-if="provider === 'FAVORITE' && !hasFavoriteEmotes()">
 				<div class="seventv-promotion-personal-emotes">
 					<div>
-						<p v-t="'emote_menu.favorite_emotes_promo_1'" />
-						<span v-t="'emote_menu.favorite_emotes_promo_2'" />
+						<p v-t="'emote_menu.personal_emotes_hint_1'" />
+						<i18n-t keypath="emote_menu.personal_emotes_hint_2" tag="span">
+							<template #HOTKEY>
+								<strong>ALT</strong>
+							</template>
+						</i18n-t>
 					</div>
 				</div>
 			</template>


### PR DESCRIPTION
If user does not have any emotes favorited, there is no indication on how to favorite an emote.
This PR adds a small display on the favorites menu to suggest Alt-clicking an emote to favorite one.

I honestly have no idea what I am doing and have never used vue before so I'm sure there's some terrible bug

## Issues?
I'm noticing provider issues and can't tell if it's my own code. Certain emotes won't show up when changing between streams/refreshing but the same behavior occurs when running main locally, I think it's just being blocked by CORS. If this is just a localhost issue then hopefully everything is fine...?