### PR TITLE
Added feature where if a suffix is added to an emotes it will horizontally flip the emote

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -8,6 +8,7 @@
 -   Fixed an issue where mentioning yourself would highlight the message
 -   Fixed an issue where replying to a thread starting from your own message would highlight the message
 -   Fixed an issue where emotes would take a long time to load if external emote providers gave slow response times
+-   Added a feature to horizontal flip emotes with a suffix character modifier
 
 ### 3.0.14.1000
 

--- a/src/app/chat/Emote.vue
+++ b/src/app/chat/Emote.vue
@@ -5,7 +5,7 @@
 			class="seventv-chat-emote"
 			:srcset="unload ? '' : processSrcSet(emote)"
 			:alt="emote.name"
-			:class="{ blur: hideUnlisted && emote.data?.listed === false }"
+			:class="{ blur: hideUnlisted && emote.data?.listed === false, mirror: isMirrorEmote(emote) === true }"
 			loading="lazy"
 			decoding="async"
 			@load="onImageLoad"
@@ -135,6 +135,12 @@ const { show, hide } = useTooltip(EmoteTooltip, {
 	width: baseWidth,
 	height: baseHeight,
 });
+
+const isMirrorEmote = (emote: SevenTV.ActiveEmote): boolean => {
+	const mirror: boolean = emote.name.slice(-2) === "_M";
+	if (emote.data) emote.data.mirrored = mirror;
+	return mirror;
+};
 </script>
 
 <style scoped lang="scss">
@@ -163,6 +169,10 @@ svg.seventv-emoji {
 img.blur {
 	filter: blur(16px);
 	overflow: clip;
+}
+
+img.mirror {
+	transform: scaleX(-1);
 }
 
 img.zero-width-emote {

--- a/src/app/chat/EmoteTooltip.vue
+++ b/src/app/chat/EmoteTooltip.vue
@@ -51,6 +51,7 @@
 				<div v-if="isChannel" class="label-channel">Channel Emote</div>
 				<div v-if="isPersonal" class="label-sub-feature">Personal Emote</div>
 				<div v-if="isZeroWidth" class="label-sub-feature">Zero-Width</div>
+				<div v-if="isMirrorEmote">Mirrored</div>
 			</div>
 
 			<!-- Emoji Data -->
@@ -120,6 +121,7 @@ const isSubscriber = props.emote.scope === "SUB";
 const isChannel = props.emote.scope === "CHANNEL";
 const isPersonal = props.emote.scope === "PERSONAL";
 const isZeroWidth = (props.emote.flags || 0 & 256) !== 0;
+const isMirrorEmote = props.emote.data?.mirrored && true;
 
 const emojiData = ref<Emoji | null>(null);
 if (props.emote.unicode) {

--- a/src/types/app.d.ts
+++ b/src/types/app.d.ts
@@ -23,6 +23,7 @@ declare namespace SevenTV {
 		owner: User | null;
 		host: ImageHost;
 		versions?: EmoteVersion[];
+		mirrored?: boolean;
 	}
 
 	interface EmoteVersion {


### PR DESCRIPTION
related feature https://github.com/SevenTV/Extension/issues/364 


after creating this PR i noticed few problems:
lets say the mirror suffix is `_M`
* if an emote already exist that has `_M` at the end it mirrors it. it shouldn't do that
* if a user wants to upload an emote with `_M` letters at end 7tv shouldn't let them upload them or at least warn them and i think there might be more requests like this for examples :
    * invert colors
    * make it continuously rotate
    * turn it 90,180 ... degrees
or even something like that we have natively in twitch like `emote_BW` makes black and white, `emote_SG`(probably zerowidth emote dose this) puts sunglasses etc. for that 7tv should reserve some suffix which might be annoying
