### PR TITLE
fix: Extension menu don't show in chrome

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -12,6 +12,7 @@
 -   Fixed "hidden subscription status" message in the User Card
 -   Fixed extraneous emote menu blank space when "Live Input Search" was enabled
 -   Fixed an issue with deleting messages using mod icons
+-   Fixed an issue where the extension menu displayed incorrectly in Chromium-based browsers
 
 ### 3.0.15.1000
 

--- a/src/app/options/Options.vue
+++ b/src/app/options/Options.vue
@@ -87,6 +87,7 @@ body[data-seventv-app] {
 .seventv-options {
 	height: 100%;
 	background: var(--seventv-background-shade-1);
+	width: max-content;
 
 	&.no-header {
 		background: none;

--- a/src/app/options/Options.vue
+++ b/src/app/options/Options.vue
@@ -85,8 +85,6 @@ body[data-seventv-app] {
 }
 
 .seventv-options {
-	display: flex;
-	flex-direction: column;
 	height: 100%;
 	background: var(--seventv-background-shade-1);
 


### PR DESCRIPTION
I have fixed the problem that made the extension menu look like a line. Removing a display that caused the issue.

![image](https://github.com/SevenTV/Extension/assets/131289272/15a00f3c-8dbc-4713-952c-641f6ca7a304)

