### PR TITLE
added iframe support

### DIFF
--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -50,6 +50,7 @@ export async function getManifest(opt: ManifestOptions): Promise<Manifest.WebExt
 			{
 				matches: ["*://*.twitch.tv/*"],
 				js: ["content.js"],
+				"all_frames":true
 			},
 		],
 		options_ui: {


### PR DESCRIPTION
added: `"all_frames": true` under content scripts in the manifest to allow 7tv to work in Iframes.