### PR TITLE
Fix delete message functionality

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -8,6 +8,7 @@
 -   Fixed emote tile width in emote menu
 -   Fixed "hidden subscription status" message in the User Card
 -   Fixed extraneous emote menu blank space when "Live Input Search" was enabled
+-   Fixed an issue with deleting messages using mod icons
 
 ### 3.0.15.1000
 

--- a/src/assets/gql/tw.chat-delete.gql.ts
+++ b/src/assets/gql/tw.chat-delete.gql.ts
@@ -1,0 +1,34 @@
+import gql from "graphql-tag";
+
+export const twitchDeleteMessageQuery = gql`
+	mutation Chat_DeleteChatMessage($input: DeleteChatMessageInput!) {
+		deleteChatMessage(input: $input) {
+			responseCode
+			message {
+				id
+				sender {
+					id
+					login
+					displayName
+				}
+				content {
+					text
+				}
+			}
+		}
+	}
+`;
+
+export namespace twitchDeleteMessageQuery {
+	export interface Variables {
+		input: {
+			channelID: string;
+			messageID: string;
+		};
+	}
+	export interface Result {
+		id: string;
+		sender: null | object;
+		content: null | object;
+	}
+}

--- a/src/composable/chat/useChatModeration.ts
+++ b/src/composable/chat/useChatModeration.ts
@@ -1,13 +1,11 @@
 import { twitchBanUserQuery, twitchUnbanUserQuery } from "@/assets/gql/tw.chat-bans.gql";
+import { twitchDeleteMessageQuery } from "@/assets/gql/tw.chat-delete.gql";
 import { twitchPinMessageQuery } from "@/assets/gql/tw.chat-pin.gql";
 import { ModOrUnmodUser, twitchModUserMut, twitchUnmodUserMut } from "@/assets/gql/tw.mod-user.gql";
-import { useChatMessages } from "./useChatMessages";
 import { ChannelContext } from "../channel/useChannelContext";
 import { useApollo } from "../useApollo";
 
 export function useChatModeration(ctx: ChannelContext, victim: string) {
-	const messages = useChatMessages(ctx);
-
 	/**
 	 * Ban the user from the chat room
 	 *
@@ -87,7 +85,18 @@ export function useChatModeration(ctx: ChannelContext, victim: string) {
 	}
 
 	function deleteChatMessage(msgID: string) {
-		messages.sendMessage(`/delete ${msgID}`);
+		const apollo = useApollo();
+		if (!apollo) return Promise.reject("Missing Apollo");
+
+		return apollo.mutate<twitchDeleteMessageQuery.Result, twitchDeleteMessageQuery.Variables>({
+			mutation: twitchDeleteMessageQuery,
+			variables: {
+				input: {
+					channelID: ctx.id,
+					messageID: msgID,
+				},
+			},
+		});
 	}
 
 	return {

--- a/src/composable/chat/useChatModeration.ts
+++ b/src/composable/chat/useChatModeration.ts
@@ -6,6 +6,8 @@ import { ChannelContext } from "../channel/useChannelContext";
 import { useApollo } from "../useApollo";
 
 export function useChatModeration(ctx: ChannelContext, victim: string) {
+	const apollo = useApollo();
+
 	/**
 	 * Ban the user from the chat room
 	 *
@@ -15,7 +17,6 @@ export function useChatModeration(ctx: ChannelContext, victim: string) {
 	 * @param reason the reason for the ban
 	 */
 	function banUserFromChat(expiresIn: string | null, reason?: string) {
-		const apollo = useApollo();
 		if (!apollo) return Promise.reject("Missing Apollo");
 
 		return apollo.mutate<twitchBanUserQuery.Result, twitchBanUserQuery.Variables>({
@@ -38,7 +39,6 @@ export function useChatModeration(ctx: ChannelContext, victim: string) {
 	 * @param victim the login of the user to unban
 	 */
 	function unbanUserFromChat() {
-		const apollo = useApollo();
 		if (!apollo) return Promise.reject("Missing Apollo");
 
 		return apollo.mutate({
@@ -53,7 +53,6 @@ export function useChatModeration(ctx: ChannelContext, victim: string) {
 	}
 
 	function pinChatMessage(msgID: string, duration: number) {
-		const apollo = useApollo();
 		if (!apollo) return Promise.reject("Missing Apollo");
 
 		return apollo.mutate<twitchPinMessageQuery.Result, twitchPinMessageQuery.Variables>({
@@ -70,7 +69,6 @@ export function useChatModeration(ctx: ChannelContext, victim: string) {
 	}
 
 	function setUserModerator(victimID: string, mod: boolean) {
-		const apollo = useApollo();
 		if (!apollo) return Promise.reject("Missing Apollo");
 
 		return apollo.mutate<ModOrUnmodUser.Response, ModOrUnmodUser.Variables>({
@@ -85,7 +83,6 @@ export function useChatModeration(ctx: ChannelContext, victim: string) {
 	}
 
 	function deleteChatMessage(msgID: string) {
-		const apollo = useApollo();
 		if (!apollo) return Promise.reject("Missing Apollo");
 
 		return apollo.mutate<twitchDeleteMessageQuery.Result, twitchDeleteMessageQuery.Variables>({


### PR DESCRIPTION
Fixed the functionality of the delete message function to use Apollo instead of IRC, this conforms with how Twitch natively handles deleting messages. This will also fix issues where users are failing to delete messages seen in the image below.

Issue:
![image](https://github.com/SevenTV/Extension/assets/76515905/cd6b2e69-d804-426f-9041-3d7abdcdc3ce)