### PR TITLE
Fix popup menu rendering improperly

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -8,6 +8,7 @@
 -   Fixed emote tile width in emote menu
 -   Fixed "hidden subscription status" message in the User Card
 -   Fixed extraneous emote menu blank space when "Live Input Search" was enabled
+-   Fixed an issue with the popup menu being rendered improperly
 
 ### 3.0.15.1000
 

--- a/src/app/options/views/Popup/Popup.vue
+++ b/src/app/options/views/Popup/Popup.vue
@@ -10,6 +10,10 @@ import PopupInner from './PopupInner.vue';
 
 <script setup lang="ts">
 import PopupInner from "./PopupInner.vue";
+
+// Set the dimensions of the popup
+document.body.style.height = "600px";
+document.body.style.width = "800px";
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
This will fix the popup menu being rendered improperly on chrome browsers.

Issue:
![image](https://github.com/SevenTV/Extension/assets/76515905/c5780f15-2f78-4309-b50b-ed16ec72bb43)
