### PR TITLE
fix: personal emote sets expire & concurrent use

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -11,6 +11,7 @@ overrides:
       extends:
           - "stylelint-config-standard-scss"
     - files: ["**/*.vue"]
+	  customSyntax: "postcss-html"
       extends:
           - "stylelint-config-standard-scss"
           - "stylelint-config-standard-vue/scss"

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -11,7 +11,7 @@ overrides:
       extends:
           - "stylelint-config-standard-scss"
     - files: ["**/*.vue"]
-	  customSyntax: "postcss-html"
+      customSyntax: "postcss-html"
       extends:
           - "stylelint-config-standard-scss"
           - "stylelint-config-standard-vue/scss"

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -4,6 +4,8 @@
 
 -   Added an option to select alternating background color for chat messages
 -   Added a tip to the favorite menu to help users favorite emotes if none are found
+-   Fixed an issue where personal emote sets remained in cache forever
+-   Fixed an issue which prevented users from using two different personal emote sets at once
 -   Fixed an issue with tab auto-completion on Kick
 -   Fixed emote tile width in emote menu
 -   Fixed "hidden subscription status" message in the User Card

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "7TV",
 	"description": "Improve your viewing experience on Twitch & YouTube with new features, emotes, vanity and performance.",
 	"private": true,
-	"version": "3.0.15",
+	"version": "3.0.16",
 	"dev_version": "1.0",
 	"scripts": {
 		"start": "NODE_ENV=dev yarn build:dev && NODE_ENV=dev vite --mode dev",

--- a/src/composable/useCosmetics.ts
+++ b/src/composable/useCosmetics.ts
@@ -236,9 +236,13 @@ db.ready().then(async () => {
 				data.sets[setID] = es.value;
 
 				// Re-assign the user's personal emote map
-				data.userEmoteMap[userID] = es.value.emotes
+				const e = es.value.emotes
 					.filter((ae) => ae.data && ae.data.state?.includes("PERSONAL")) // filter out emotes that are not personal-use approved
 					.reduce((acc, cur) => ({ ...acc, [cur.name]: cur }), {} as Record<string, SevenTV.ActiveEmote>);
+
+				for (const eid in e) {
+					data.userEmoteMap[userID][eid] = e[eid];
+				}
 
 				// Update the set's data
 				data.userEmoteSets[userID]?.set(setID, es.value);

--- a/src/composable/useWorker.ts
+++ b/src/composable/useWorker.ts
@@ -3,6 +3,8 @@ import { TypedEventListenerOrEventListenerObject } from "@/common/EventTarget";
 import { Logger, log } from "@/common/Logger";
 import { TypedWorkerMessage, WorkerMessage, WorkerMessageType } from "@/worker";
 
+let workerURL: string | null;
+
 const workerLog = new Logger();
 workerLog.setContextName("Worker/Pipe");
 
@@ -26,8 +28,7 @@ async function init(originURL: string): Promise<SharedWorker> {
 		localStorage.removeItem(LOCAL_STORAGE_KEYS.WORKER_ADDR);
 	}
 
-	let workerURL: string | null =
-		typeof workerAddr === "object" && workerAddr !== null ? workerAddr[appVersion] : null;
+	workerURL = typeof workerAddr === "object" && workerAddr !== null ? workerAddr[appVersion] : null;
 
 	const ok =
 		workerURL &&

--- a/src/db/idb.ts
+++ b/src/db/idb.ts
@@ -116,6 +116,8 @@ export class Dexie7 extends Dexie {
 			this.emoteSets
 				.where("id")
 				.anyOf(channels.map((c) => c.set_ids).reduce((a, b) => a.concat(b), []))
+				.or("timestamp")
+				.below(now - oneHour)
 				.delete();
 
 			// Clean up entitlements


### PR DESCRIPTION
Fixing a few issues involving personal emote sets, where a lack of expiration leads to eventual clogging of IndexedDB and reduced performance, as well as that users with multiple personal emote sets couldn't actually use them both at once.