### PR TITLE
fix(chat): broken 24h timestamp

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -3,6 +3,7 @@
 **The changes listed here are not assigned to an official release**.
 
 -   Reinstated animated avatars
+-   Fixed an issue which caused timestamps to count beyond 24 hours
 
 ### 3.0.16.1000
 

--- a/src/app/chat/UserMessage.vue
+++ b/src/app/chat/UserMessage.vue
@@ -231,9 +231,9 @@ const useTimestampFormat = () => {
 		case "infer":
 			return undefined;
 		case "12":
-			return true;
+			return "h12";
 		case "24":
-			return false;
+			return "h23";
 	}
 };
 
@@ -256,7 +256,7 @@ watchEffect(() => {
 				hour: "2-digit",
 				minute: "2-digit",
 				second: displaySecondsInTimestamp.value ? "numeric" : undefined,
-				hour12: useTimestampFormat(),
+				hourCycle: useTimestampFormat(),
 			},
 			props.msg.timestamp,
 		);

--- a/src/app/chat/UserMessage.vue
+++ b/src/app/chat/UserMessage.vue
@@ -256,7 +256,7 @@ watchEffect(() => {
 				hour: "2-digit",
 				minute: "2-digit",
 				second: displaySecondsInTimestamp.value ? "numeric" : undefined,
-				hourCycle: useTimestampFormat(),
+				...{ hourCycle: useTimestampFormat() },
 			},
 			props.msg.timestamp,
 		);


### PR DESCRIPTION
Using the 24-hour timestamp format would cause the time to start counting beyond the 24 hour mark. It would result in the time to display "24:01:59" as opposed to "00:01:59". See the following example:

![before](https://github.com/SevenTV/Extension/assets/29018740/f9b39f43-7d48-45a5-a05e-dd38221e9748)

which should now display instead:

![after](https://github.com/SevenTV/Extension/assets/29018740/d7fd042e-86c9-42e0-a748-f240687ed936)

Should fix #929 