### PR TITLE
fix(twitch): sidebar stream thumbnails

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -3,6 +3,7 @@
 **The changes listed here are not assigned to an official release**.
 
 -   Reinstated animated avatars
+-   Fixed an issue with non-English names not displaying sidebar preview image on hover
 
 ### 3.0.16.1000
 

--- a/src/site/twitch.tv/modules/sidebar-previews/SidebarCard.vue
+++ b/src/site/twitch.tv/modules/sidebar-previews/SidebarCard.vue
@@ -70,20 +70,12 @@ function patchTooltip(tooltip: ReactExtended.ReactRuntimeElement, vnode: ReactEx
 		props: {
 			className: "seventv-sidebar-tooltip-preview",
 			style: {
-				backgroundImage: getThumbnail(tooltip.props.channelDisplayName?.toLowerCase() ?? "???"),
+				backgroundImage: `url(${tooltip.props.streamPreviewImage})`,
 			},
 		},
 	});
 
 	return vnode;
-}
-
-function getThumbnail(channel: string) {
-	let url = `https://static-cdn.jtvnw.net/previews-ttv/live_user_${channel}-190x107.jpg`;
-
-	url += `?${Math.floor(Date.now() / 300000)}`;
-
-	return `url("${url}")`;
 }
 
 onUnmounted(() => {

--- a/src/site/twitch.tv/modules/sidebar-previews/SidebarCard.vue
+++ b/src/site/twitch.tv/modules/sidebar-previews/SidebarCard.vue
@@ -70,12 +70,17 @@ function patchTooltip(tooltip: ReactExtended.ReactRuntimeElement, vnode: ReactEx
 		props: {
 			className: "seventv-sidebar-tooltip-preview",
 			style: {
-				backgroundImage: `url(${tooltip.props.streamPreviewImage})`,
+				backgroundImage: getThumbnail(tooltip.props.streamPreviewImage),
 			},
 		},
 	});
 
 	return vnode;
+}
+
+function getThumbnail(previewURL: string) {
+	const url = previewURL.concat(`?${Math.floor(Date.now() / 300000)}`);
+	return `url(${url})`;
 }
 
 onUnmounted(() => {

--- a/src/site/twitch.tv/modules/sidebar-previews/SidebarCard.vue
+++ b/src/site/twitch.tv/modules/sidebar-previews/SidebarCard.vue
@@ -11,6 +11,8 @@ const props = defineProps<{
 	instance: HookedInstance<Twitch.SidebarCardComponent>;
 }>();
 
+const SIDEBAR_PREVIEW_FALLBACK = "https://vod-secure.twitch.tv/_404/404_processing_320x180.png";
+
 const showPreviews = useConfig<boolean>("ui.sidebar_previews");
 
 const tooltipContent = ref<ReactExtended.ReactRuntimeElement>();
@@ -70,7 +72,7 @@ function patchTooltip(tooltip: ReactExtended.ReactRuntimeElement, vnode: ReactEx
 		props: {
 			className: "seventv-sidebar-tooltip-preview",
 			style: {
-				backgroundImage: getThumbnail(tooltip.props.streamPreviewImage),
+				backgroundImage: getThumbnail(tooltip.props.streamPreviewImage ?? SIDEBAR_PREVIEW_FALLBACK),
 			},
 		},
 	});


### PR DESCRIPTION
Attempting to view a preview of a stream by hovering over their profile in the sidebar would cause streamers with a "non-English" name to not have their thumbnails show up. See the following example:

![before](https://github.com/SevenTV/Extension/assets/29018740/8845e115-b5d3-4e56-90b6-1255f5d61928)

which should now display instead:

![after](https://github.com/SevenTV/Extension/assets/29018740/07f87440-0344-4f7e-858d-4eb766f3cf01)

Should fix #933 