### PR TITLE
fix(twitch): experiment category scroll

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -3,6 +3,7 @@
 **The changes listed here are not assigned to an official release**.
 
 -   Reinstated animated avatars
+-   Fixed an issue which caused scrolling to not work while scrolling through a category
 
 ### 3.0.16.1000
 

--- a/src/site/twitch.tv/modules/avatars/AvatarsModule.vue
+++ b/src/site/twitch.tv/modules/avatars/AvatarsModule.vue
@@ -123,7 +123,7 @@ function doRerender() {
 			}
 
 			if (returnCom.stateNode) {
-				if ("forceUpdate" in returnCom.stateNode) {
+				if ("forceUpdate" in returnCom.stateNode && returnCom.stateNode.props?.name) {
 					componentsToForceUpdate.add(returnCom.stateNode);
 					break;
 				}


### PR DESCRIPTION
Scrolling through the streams inside of a specific category can lock up after initial page load / while scrolling down. 

This issue seems to happen because the `AvatarsModule` patches and re-renders the avatars after updating their properties. However, it seems like during re-rendering it grabs a "wrong" virtual node (the scroll container) which breaks the component and thus not allowing the user to scroll. See the following example:

https://github.com/SevenTV/Extension/assets/29018740/98dfe5f6-176d-498a-88d6-af05ab7f1590

which should now work like this:

https://github.com/SevenTV/Extension/assets/29018740/09d9cc74-69b4-4185-9b28-2701547ede6f

This also seems to have fixed the issue that was also fixed in #968

Should fix: #635, fix #977