### PR TITLE
fix(twitch): experiment category scroll

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -3,6 +3,7 @@
 **The changes listed here are not assigned to an official release**.
 
 -   Reinstated animated avatars
+-   Fixed an issue which caused scrolling to not work while scrolling through a category
 
 ### 3.0.16.1000
 

--- a/src/site/twitch.tv/modules/avatars/AvatarsModule.vue
+++ b/src/site/twitch.tv/modules/avatars/AvatarsModule.vue
@@ -4,7 +4,7 @@
 import { onMounted, onUnmounted, reactive, ref, watch } from "vue";
 import { watchDebounced } from "@vueuse/core";
 import { ObserverPromise } from "@/common/Async";
-import { getVNodeFromDOM } from "@/common/ReactHooks";
+import { findComponentParents, getVNodeFromDOM } from "@/common/ReactHooks";
 import { defineFunctionHook, unsetPropertyHook } from "@/common/Reflection";
 import { db } from "@/db/idb";
 import { declareModule } from "@/composable/useModule";
@@ -123,7 +123,20 @@ function doRerender() {
 			}
 
 			if (returnCom.stateNode) {
-				if ("forceUpdate" in returnCom.stateNode) {
+				// to avoid simplebar from breaking, we need to update the parent
+				// holding the ref instead.
+				if ("simplebarRef" in returnCom.stateNode) {
+					const [parent] = findComponentParents(
+						returnCom,
+						(component) => component.setRootScrollableContentRef !== undefined,
+						undefined,
+						1,
+					);
+					if (parent) {
+						componentsToForceUpdate.add(parent);
+						break;
+					}
+				} else if ("forceUpdate" in returnCom.stateNode) {
 					componentsToForceUpdate.add(returnCom.stateNode);
 					break;
 				}
@@ -134,7 +147,7 @@ function doRerender() {
 	}
 
 	for (const com of componentsToForceUpdate) {
-		for (let i = 0; i < 2; i++) com.forceUpdate();
+		com.forceUpdate();
 	}
 
 	for (const [com, key] of oldKeys) {
@@ -197,7 +210,7 @@ function assignAvatar(av: SevenTV.Cosmetic<"AVATAR">) {
 watchDebounced(
 	avatars,
 	() => {
-		doRerender();
+		if (shouldRenderAvatars.value) doRerender();
 	},
 	{
 		debounce: 350,

--- a/src/site/twitch.tv/modules/avatars/AvatarsModule.vue
+++ b/src/site/twitch.tv/modules/avatars/AvatarsModule.vue
@@ -147,7 +147,7 @@ function doRerender() {
 	}
 
 	for (const com of componentsToForceUpdate) {
-		com.forceUpdate();
+		for (let i = 0; i < 2; ++i) com.forceUpdate();
 	}
 
 	for (const [com, key] of oldKeys) {


### PR DESCRIPTION
Scrolling through the streams inside of a specific category can lock up after initial page load / while scrolling down. 

This issue seems to happen because the `AvatarsModule` patches and re-renders the avatars after updating their properties. However, it seems like during re-rendering it grabs a virtual node holding the cards where you actually scroll through. Updating that container (instead of it's parent holding it's ref) will cause [simplebar](https://github.com/Grsmto/simplebar) to break and delete containers.

https://github.com/SevenTV/Extension/assets/29018740/98dfe5f6-176d-498a-88d6-af05ab7f1590

which should now work like this:

https://github.com/SevenTV/Extension/assets/29018740/09d9cc74-69b4-4185-9b28-2701547ede6f

Should fix: #635