### PR TITLE
fix(twitch): support lowercase cheers

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -3,6 +3,7 @@
 **The changes listed here are not assigned to an official release**.
 
 -   Reinstated animated avatars
+-   Fixed an issue where lowercase cheers were displayed as text
 
 ### 3.0.16.1000
 

--- a/src/site/twitch.tv/modules/chat-vod/ChatVod.vue
+++ b/src/site/twitch.tv/modules/chat-vod/ChatVod.vue
@@ -217,7 +217,7 @@ function createMessageComponentRef(data: CommentData) {
 				const e = tok.content as Twitch.ChatMessage.EmotePart["content"];
 				if (!e.alt) continue;
 
-				msg.nativeEmotes[e.alt + (e.cheerAmount ?? "")] = {
+				const nativeEmote: SevenTV.ActiveEmote = {
 					id: e.emoteID ?? "",
 					name: e.alt,
 					flags: 0,
@@ -238,7 +238,14 @@ function createMessageComponentRef(data: CommentData) {
 								token: e.alt,
 						  } as Partial<Twitch.TwitchEmote>),
 				};
+				const emoteName = e.alt + (e.cheerAmount ?? "");
 
+				msg.nativeEmotes[emoteName] = nativeEmote;
+
+				// if it's a cheer we also want to support it's lowercase variant (e.g. Cheer1 & cheer1)
+				if (e.cheerAmount) {
+					msg.nativeEmotes[emoteName.toLowerCase()] = nativeEmote;
+				}
 				msg.body += e.alt;
 				break;
 			}

--- a/src/site/twitch.tv/modules/chat/ChatList.vue
+++ b/src/site/twitch.tv/modules/chat/ChatList.vue
@@ -245,7 +245,7 @@ function onChatMessage(msg: ChatMessage, msgData: Twitch.AnyMessage, shouldRende
 					// skip over emotes patched in by FFZ and BTTV
 					if (e.emoteID?.startsWith("__FFZ__") || e.emoteID?.startsWith("__BTTV__")) continue;
 
-					msg.nativeEmotes[e.alt + (e.cheerAmount ?? "")] = {
+					const nativeEmote: SevenTV.ActiveEmote = {
 						id: e.emoteID ?? "",
 						name: e.alt,
 						flags: 0,
@@ -266,6 +266,14 @@ function onChatMessage(msg: ChatMessage, msgData: Twitch.AnyMessage, shouldRende
 									token: e.alt,
 							  } as Partial<Twitch.TwitchEmote>),
 					};
+					const emoteName = e.alt + (e.cheerAmount ?? "");
+
+					msg.nativeEmotes[emoteName] = nativeEmote;
+
+					// if it's a cheer we also want to support it's lowercase variant (e.g. Cheer1 & cheer1)
+					if (e.cheerAmount) {
+						msg.nativeEmotes[emoteName.toLowerCase()] = nativeEmote;
+					}
 					break;
 				}
 				// replace flagged segments


### PR DESCRIPTION
If a user sends a cheer in chat it is meant to be turned into an emote with it's text colored differently. It can be sent as it's lowercase and uppercase variant (e.g. "cheer1" & "Cheer1"). 7TV currently seems to only support the uppercase variant.

See the following example (msg lit. "cheer123456 Cheer123456"):

![before](https://github.com/SevenTV/Extension/assets/29018740/e54775f1-69a2-4043-a0a2-476fbd6dda84)

which should now look like this:

![after](https://github.com/SevenTV/Extension/assets/29018740/5a9a1d1a-08bf-4b53-b564-918b6b63ea38)

Should fix: #453 