### PR TITLE
fix: wrap emote alias

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -3,6 +3,7 @@
 **The changes listed here are not assigned to an official release**.
 
 -   Reinstated animated avatars
+-   Fixed an issue where an emote with a long alias would cause the alias to go outside of the tooltip
 
 ### 3.0.16.1000
 

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -3,9 +3,9 @@
 **The changes listed here are not assigned to an official release**.
 
 -   Reinstated animated avatars
--   Fixed an issue where an emote with a long alias would cause the alias to go outside of the tooltip
 -   Added an option to hide the community challenge contributions in the chat
 -   Fixed extension not working on twitch for some users (React 18 support)
+-   Fixed an issue where an emote with a long alias would cause the alias to go outside of the tooltip
 
 ### 3.0.16.1000
 

--- a/src/app/chat/EmoteTooltip.vue
+++ b/src/app/chat/EmoteTooltip.vue
@@ -163,6 +163,11 @@ if (props.emote.data?.owner?.style?.color) {
 	float: left;
 }
 
+.alias-label {
+	word-break: break-all;
+	text-align: center;
+}
+
 .logo {
 	width: 2rem;
 	height: auto;


### PR DESCRIPTION
If an emote had a long alias and was hovered over, the alias would overflow outside of the tooltip. See the following example:

![image](https://github.com/SevenTV/Extension/assets/29018740/92c3ec15-d908-4d00-8900-a46000f1ab83)

which should now look like the following:

![image](https://github.com/SevenTV/Extension/assets/29018740/89e9f0ad-1c23-4791-977e-8172f038716f)
