### PR TITLE
fix(twitch): use accent color in chat announcements

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -3,6 +3,7 @@
 **The changes listed here are not assigned to an official release**.
 
 -   Reinstated animated avatars
+-   Fixed an issue where chat announcements did not use the channel accent color
 
 ### 3.0.16.1000
 

--- a/src/app/chat/msg/49.AnnouncementMessage.vue
+++ b/src/app/chat/msg/49.AnnouncementMessage.vue
@@ -64,6 +64,6 @@ const className =
 
 /* stylelint-disable-next-line selector-class-pattern */
 .announcement-line--primary {
-	border-color: var(--seventv-primary-color, currentColor);
+	border-color: var(--seventv-channel-accent, currentColor);
 }
 </style>


### PR DESCRIPTION
Fixed a small typo which caused chat announcements to not use the channel's accent color and instead used a white color. See the examples below:

![image](https://github.com/SevenTV/Extension/assets/29018740/95362ddf-92ad-4b9a-bd2b-4314a8366d55)

which should now look like this:

![image](https://github.com/SevenTV/Extension/assets/29018740/b7d636c1-dd80-4214-a1fd-edc39d2feb6e)

and this is the channel's profile for reference

![image](https://github.com/SevenTV/Extension/assets/29018740/db2034ae-63a2-4ca8-88fa-f3f67f8a5fc4)
