### PR TITLE
fix(twitch): chat accent color

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -3,9 +3,9 @@
 **The changes listed here are not assigned to an official release**.
 
 -   Reinstated animated avatars
--   Fixed an issue where chat messages (like announcements) did not use the channel accent color
 -   Added an option to hide the community challenge contributions in the chat
 -   Fixed extension not working on twitch for some users (React 18 support)
+-   Fixed an issue where chat messages (like announcements) did not use the channel accent color
 
 ### 3.0.16.1000
 

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -3,6 +3,7 @@
 **The changes listed here are not assigned to an official release**.
 
 -   Reinstated animated avatars
+-   Fixed an issue where chat messages (like announcements) did not use the channel accent color
 
 ### 3.0.16.1000
 

--- a/src/app/chat/msg/14.SubscriptionMessage.vue
+++ b/src/app/chat/msg/14.SubscriptionMessage.vue
@@ -43,7 +43,7 @@ const plan = props.msgData.methods?.plan == "Prime" ? "Prime" : "Tier " + props.
 }
 
 .seventv-highlight {
-	border-left: 0.4rem solid var(--seventv-primary-color);
+	border-left: 0.4rem solid var(--seventv-channel-accent);
 	padding-left: 1.6rem !important;
 }
 

--- a/src/app/chat/msg/15.Resubscription.vue
+++ b/src/app/chat/msg/15.Resubscription.vue
@@ -49,7 +49,7 @@ const plan = props.msgData.methods?.plan == "Prime" ? "Prime" : "Tier " + props.
 }
 
 .seventv-highlight {
-	border-left: 0.4rem solid var(--seventv-primary-color);
+	border-left: 0.4rem solid var(--seventv-channel-accent);
 	padding-left: 1.6rem !important;
 }
 

--- a/src/app/chat/msg/21.SubGift.vue
+++ b/src/app/chat/msg/21.SubGift.vue
@@ -36,7 +36,7 @@ defineProps<{
 }
 
 .seventv-highlight {
-	border-left: 0.4rem solid var(--seventv-primary-color);
+	border-left: 0.4rem solid var(--seventv-channel-accent);
 	padding-left: 1.6rem !important;
 }
 

--- a/src/app/chat/msg/35.SubMysteryGift.vue
+++ b/src/app/chat/msg/35.SubMysteryGift.vue
@@ -40,7 +40,7 @@ defineProps<{
 }
 
 .seventv-highlight {
-	border-left: 0.4rem solid var(--seventv-primary-color);
+	border-left: 0.4rem solid var(--seventv-channel-accent);
 	padding-left: 1.6rem !important;
 }
 

--- a/src/app/chat/msg/49.AnnouncementMessage.vue
+++ b/src/app/chat/msg/49.AnnouncementMessage.vue
@@ -64,6 +64,6 @@ const className =
 
 /* stylelint-disable-next-line selector-class-pattern */
 .announcement-line--primary {
-	border-color: var(--seventv-primary-color, currentColor);
+	border-color: var(--seventv-channel-accent, currentColor);
 }
 </style>


### PR DESCRIPTION
Fixed an issue where a channel's accent colors were not used in chat. It caused messages like announcements, (re)subscriptions and gifted subscriptions to fall back onto a white accent color or none. See a few snippets below:

![image](https://github.com/SevenTV/Extension/assets/29018740/b03a6944-2d3c-4e42-830e-cff4e5d86647)

which should now look like:

![image](https://github.com/SevenTV/Extension/assets/29018740/6243e037-d3b0-4334-ad9a-f4ca4e3a27b9)

and

![image](https://github.com/SevenTV/Extension/assets/29018740/36ad7c04-a2ae-41b2-99f6-278c2a22b07b)

should now look like this:

![image](https://github.com/SevenTV/Extension/assets/29018740/eadafa2c-b5c9-420c-ba52-814dbe745829)
