### PR TITLE
fix(twitch): badges not displayed

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -15,6 +15,7 @@
 -   Fixed an issue where chat messages (like announcements) did not use the channel accent color
 -   Fixed an issue where an emote with a long alias would cause the alias to go outside of the tooltip
 -   Added an option to hide timestamps in vods
+-   Fixed an issue which sometimes caused chat badges to not appear
 
 ### 3.0.16.1000
 

--- a/src/app/chat/UserTag.vue
+++ b/src/app/chat/UserTag.vue
@@ -1,7 +1,10 @@
 <template>
 	<div v-if="user && user.displayName" ref="tagRef" class="seventv-chat-user" :style="{ color: user.color }">
 		<!--Badge List -->
-		<span v-if="!hideBadges && (twitchBadges.length || cosmetics.badges.size)" class="seventv-chat-user-badge-list">
+		<span
+			v-if="!hideBadges && ((twitchBadges.length && twitchBadgeSets?.count) || cosmetics.badges.size)"
+			class="seventv-chat-user-badge-list"
+		>
 			<Badge
 				v-for="badge of twitchBadges"
 				:key="badge.id"
@@ -43,7 +46,7 @@
 </template>
 
 <script setup lang="ts">
-import { nextTick, ref, toRef, watch } from "vue";
+import { nextTick, ref, toRef, watch, watchEffect } from "vue";
 import type { ChatUser } from "@/common/chat/ChatMessage";
 import { useChannelContext } from "@/composable/channel/useChannelContext";
 import { useChatProperties } from "@/composable/chat/useChatProperties";
@@ -78,8 +81,8 @@ const cosmetics = useCosmetics(props.user.id);
 const shouldRenderPaint = useConfig("vanity.nametag_paints");
 const betterUserCardEnabled = useConfig("chat.user_card");
 const twitchBadges = ref<Twitch.ChatBadge[]>([]);
-
 const twitchBadgeSets = toRef(properties, "twitchBadgeSets");
+
 const tagRef = ref<HTMLDivElement>();
 const showUserCard = ref(false);
 const cardHandle = ref<HTMLDivElement>();
@@ -96,36 +99,27 @@ function handleClick(ev: MouseEvent) {
 	showUserCard.value = !showUserCard.value;
 }
 
-const stopWatchSets = watch(
-	twitchBadgeSets,
-	(badgeSets) => {
-		if (props.badges && badgeSets && badgeSets.count > 0) {
-			for (const [key, value] of Object.entries(props.badges)) {
-				const setID = key;
-				const badgeID = value;
+watchEffect(() => {
+	if (props.badges && twitchBadgeSets.value && !twitchBadges.value.length) {
+		for (const [key, value] of Object.entries(props.badges)) {
+			const setID = key;
+			const badgeID = value;
 
-				for (const setGroup of [badgeSets.channelsBySet, badgeSets.globalsBySet]) {
-					if (!setGroup) continue;
+			for (const setGroup of [twitchBadgeSets.value.channelsBySet, twitchBadgeSets.value.globalsBySet]) {
+				if (!setGroup) continue;
 
-					const set = setGroup.get(setID);
-					if (!set) continue;
+				const set = setGroup.get(setID);
+				if (!set) continue;
 
-					const badge = set.get(badgeID);
-					if (!badge) continue;
+				const badge = set.get(badgeID);
+				if (!badge) continue;
 
-					twitchBadges.value.push(badge);
-					break;
-				}
+				twitchBadges.value.push(badge);
+				break;
 			}
 		}
-		// If there are no badges to be rendered or the badges get assigned
-		// there's no need to keep watching.
-		if (!props.badges || (badgeSets && badgeSets.count > 0)) {
-			nextTick(() => stopWatchSets());
-		}
-	},
-	{ immediate: true },
-);
+	}
+});
 
 const t = Date.now();
 const stop = watch(

--- a/src/site/twitch.tv/modules/chat/ChatController.vue
+++ b/src/site/twitch.tv/modules/chat/ChatController.vue
@@ -128,13 +128,6 @@ watch(
 		definePropertyHook(inst.component, "props", {
 			value(v) {
 				messageHandler.value = v.messageHandlerAPI;
-
-				// Find message to grab some data
-				// eslint-disable-next-line @typescript-eslint/no-explicit-any
-				const msgItem = (v.children[0] as any | undefined)?.props as Twitch.ChatLineComponent["props"];
-				if (!msgItem?.badgeSets?.count) return;
-
-				properties.twitchBadgeSets = msgItem.badgeSets;
 			},
 		});
 	},
@@ -170,6 +163,7 @@ watch(
 
 		definePropertyHook(room.value.component, "props", {
 			value(v) {
+				properties.twitchBadgeSets = v.badgeSets;
 				properties.primaryColorHex = v.primaryColorHex;
 				primaryColor.value = `#${v.primaryColorHex ?? "755ebc"}`;
 				document.body.style.setProperty("--seventv-channel-accent", primaryColor.value);

--- a/src/types/twitch.d.ts
+++ b/src/types/twitch.d.ts
@@ -186,6 +186,7 @@ declare module Twitch {
 		isShowingCommunityHighlightList: boolean;
 		deletedMessageDisplay: "BRIEF" | "DETAILED" | "LEGACY";
 		chatPauseSetting: "MOUSEOVER" | "SCROLL_ONLY" | "ALTKEY" | "MOUSEOVER_ALTKEY";
+		badgeSets: BadgeSets;
 	}>;
 
 	export type ViewerCardComponent = ReactExtended.WritableComponent<{}> & {


### PR DESCRIPTION
## Proposed changes

Entering a chat sometimes caused badges to not show up (generally with historic messages). This was caused because the badge sets weren't exposed yet with the way they were extracted from it's component. The old implementation relies on a message to already be displayed, thus having no messages would cause the badge sets to not be assigned until a message is to be displayed.

This is however fixed by using the chat room component instead. It exposes the badge sets through it's props instead of it's children.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

See the following snippets:

![before_badge_fix.png](https://github.com/SevenTV/Extension/assets/29018740/65789cd0-541e-41fa-8e3a-b9f4646a21ce)

should now look like:

![after_badge_fix.png](https://github.com/SevenTV/Extension/assets/29018740/eae34ab3-2cf6-45fa-bd90-232bc02e6262)


