### PR TITLE
fix(twitch): replies in thread

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -15,6 +15,8 @@
 -   Fixed an issue where chat messages (like announcements) did not use the channel accent color
 -   Fixed an issue where an emote with a long alias would cause the alias to go outside of the tooltip
 -   Added an option to hide timestamps in vods
+-   Fixed an issue that caused replies in threads to not appear
+-   Fixed an issue where replies in threads could not be selected
 
 ### 3.0.16.1000
 

--- a/src/app/chat/UserMessageButtons.vue
+++ b/src/app/chat/UserMessageButtons.vue
@@ -84,6 +84,15 @@ const tray = useTray("Reply", () => ({
 				displayName: props.msg.author?.displayName,
 		  }
 		: {}),
+	...(props.msg.parent
+		? {
+				thread: {
+					deleted: props.msg.parent.thread?.deleted ?? props.msg.parent.deleted,
+					id: props.msg.parent.thread?.id ?? props.msg.parent.id,
+					login: props.msg.parent.thread?.login ?? props.msg.parent.author?.username ?? "",
+				},
+		  }
+		: {}),
 }));
 
 const showCopyIcon = useConfig<boolean>("chat.copy_icon_toggle");

--- a/src/common/Transform.ts
+++ b/src/common/Transform.ts
@@ -310,6 +310,7 @@ export function convertTwitchMessage(d: TwTypeMessage): ChatMessage {
 			  )
 			: {};
 	msg.timestamp = new Date(d.sentAt).getTime();
+	msg.moderation.deleted = !!d.deletedAt;
 
 	return msg;
 }

--- a/src/common/chat/ChatMessage.ts
+++ b/src/common/chat/ChatMessage.ts
@@ -193,6 +193,11 @@ export interface ChatMessageParent {
 		username: string;
 		displayName: string;
 	} | null;
+	thread: {
+		deleted?: boolean;
+		id: string;
+		login: string;
+	} | null;
 }
 
 export interface ChatMessageModeration {

--- a/src/site/twitch.tv/modules/chat/ChatList.vue
+++ b/src/site/twitch.tv/modules/chat/ChatList.vue
@@ -222,6 +222,14 @@ function onChatMessage(msg: ChatMessage, msgData: Twitch.AnyMessage, shouldRende
 				deleted: msgData.reply.parentDeleted,
 				body: msgData.reply.parentMessageBody,
 				author: parentMsgAuthor,
+				thread:
+					msgData.reply && msgData.reply.threadParentMsgId && msgData.reply.threadParentUserLogin
+						? {
+								deleted: msgData.reply.threadParentDeleted,
+								id: msgData.reply.threadParentMsgId,
+								login: msgData.reply.threadParentUserLogin,
+						  }
+						: null,
 			};
 
 			// Highlight as a reply to the actor

--- a/src/site/twitch.tv/modules/chat/components/tray/ChatTray.ts
+++ b/src/site/twitch.tv/modules/chat/components/tray/ChatTray.ts
@@ -65,6 +65,13 @@ function getReplyTray(props: TrayProps<"Reply">): Twitch.ChatTray<"Reply"> {
 								parentDisplayName: props.displayName,
 						  }
 						: {}),
+					...(props.thread
+						? {
+								threadParentMsgId: props.thread.id,
+								threadParentDeleted: props.thread.deleted,
+								threadParentUserLogin: props.thread.login,
+						  }
+						: {}),
 				},
 			},
 		},

--- a/src/site/twitch.tv/modules/chat/components/tray/tray.d.ts
+++ b/src/site/twitch.tv/modules/chat/components/tray/tray.d.ts
@@ -6,6 +6,11 @@ export type TrayProps<T extends keyof Twitch.ChatTray.Type> = {
 		deleted: boolean;
 		username?: string;
 		displayName?: string;
+		thread?: {
+			deleted: boolean;
+			id: string;
+			login: string;
+		};
 	};
 }[T] & {
 	close?: () => void;

--- a/src/types/twitch.messages.d.ts
+++ b/src/types/twitch.messages.d.ts
@@ -31,6 +31,9 @@ declare namespace Twitch {
 			parentUid: string;
 			parentUserLogin: string;
 			parentDisplayName: string;
+			threadParentDeleted?: boolean;
+			threadParentMsgId?: string;
+			threadParentUserLogin?: string;
 		};
 
 		height?: number;


### PR DESCRIPTION
## Proposed changes

Opening / replying to threads would only allow you to view up to a maximum of 2 messages (the main message and one reply). 
This is fixed by using the tray's thread props instead of just it's parent props. This PR also fixes the issue where message buttons  (copy & reply) were not being displayed when hovered over inside of a thread tray.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

See the following example of this implementation:

https://github.com/SevenTV/Extension/assets/29018740/4d6312c7-b04c-4279-a76f-2eff34f8c156
