### PR TITLE
fix: wrong id used when subscribing to user events

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -17,6 +17,7 @@
 -   Added an option to hide timestamps in vods
 -   Fixed an issue that caused replies in threads to not appear
 -   Fixed an issue where replies in threads could not be selected
+-   Fixed an issue where switching the selected emote-set would not be detected
 
 ### 3.0.16.1000
 

--- a/src/worker/worker.http.ts
+++ b/src/worker/worker.http.ts
@@ -153,9 +153,9 @@ export class WorkerHttp {
 			});
 		}
 
-		const user = await userPromise;
-		if (user) {
-			this.driver.eventAPI.subscribe("user.*", { object_id: user.id }, port, channel.id);
+		const stvUser = (await userPromise)?.user;
+		if (stvUser) {
+			this.driver.eventAPI.subscribe("user.*", { object_id: stvUser.id }, port, channel.id);
 		}
 
 		// begin subscriptions to personal events in the channel


### PR DESCRIPTION
## Proposed changes

Currently, when subscribing to the user events (AFAIK only used to listen for changes to which emote-set is selected) the user-id of the respective platform is passed as the `object_id` instead of the 7tv user-id.

![screenshot](https://i.imgur.com/JCz9ktt.png)

https://github.com/SevenTV/Extension/blob/a98e3653a0d0714f945e57d20daf53f2cf5834f0/src/worker/worker.http.ts#L156-L159

This PR just uses the 7tv user-id as the `object_id` instead.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [X] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Example

https://github.com/SevenTV/Extension/assets/42820438/272f57a4-758b-4cb1-94c6-509baa704f72


