### PR TITLE
fix(kick): emote menu button

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -17,6 +17,7 @@
 -   Added an option to hide timestamps in vods
 -   Fixed an issue that caused replies in threads to not appear
 -   Fixed an issue where replies in threads could not be selected
+-   Fixed an issue where the emote menu button did not appear on Kick
 
 ### 3.0.16.1000
 

--- a/src/site/kick.com/composable/useRouter.ts
+++ b/src/site/kick.com/composable/useRouter.ts
@@ -23,6 +23,8 @@ export function useRouter(app: App<Element>) {
 				router.currentRoute = v;
 			},
 		});
+
+		m.set(app, router);
 	}
 
 	return router;

--- a/src/site/kick.com/modules/chat/ChatEmoteMenu.vue
+++ b/src/site/kick.com/modules/chat/ChatEmoteMenu.vue
@@ -42,7 +42,7 @@ watchEffect(() => {
 	const parent = document.getElementById("chatroom");
 	if (!parent) return;
 
-	const inputRow = parent.querySelector(".chat-message-row");
+	const inputRow = parent.querySelector(".chat-input-wrapper");
 	if (!inputRow) return;
 
 	inputRow.lastElementChild?.insertAdjacentElement("beforebegin", emoteMenuButtonContainer);


### PR DESCRIPTION
## Proposed changes

A simple UI update by Kick changed the chat input container where the emote picker icon was being placed. This PR simply updates it to the new one. 

Additionally, the previous implementation never reset the channel state after leaving a channel. So re-entering the same channel (e.g. by going to the homepage and back) would cause the emote picker to also not rerender. Along with that change, if no message was dispatched by the room it would also cause the channel to never be assigned. These are both fixed by this PR.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

A snippet of what it was before:

![logged_in](https://github.com/SevenTV/Extension/assets/29018740/da1cb112-5417-433d-b042-a85e9fa0cbbd)

and after:

![logged_in](https://github.com/SevenTV/Extension/assets/29018740/c93f3260-dfca-4eae-8c0a-a8df7ba92c4d)


