### PR TITLE
fix: popup width

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -20,6 +20,7 @@
 -   Fixed an issue where replies in threads could not be selected
 -   Fixed an issue where switching the selected emote-set would not be detected
 -   Fixed an issue where the emote menu button did not appear on Kick
+-   Fixed an issue that caused the 7TV popup to appear thin
 
 ### 3.0.16.1000
 

--- a/src/app/options/Options.vue
+++ b/src/app/options/Options.vue
@@ -62,6 +62,7 @@ body[data-seventv-app] {
 #app {
 	height: 100%;
 	width: 100%;
+	min-width: min-content;
 }
 
 .general-heading {

--- a/src/app/options/views/Popup/Popup.vue
+++ b/src/app/options/views/Popup/Popup.vue
@@ -2,9 +2,7 @@ import PopupInner from './PopupInner.vue';
 
 <template>
 	<main class="seventv-popup">
-		<div>
-			<PopupInner />
-		</div>
+		<PopupInner />
 	</main>
 </template>
 
@@ -16,10 +14,7 @@ import PopupInner from "./PopupInner.vue";
 main {
 	display: block;
 	background-color: var(--seventv-background-shade-1);
-
-	> div {
-		height: 600px;
-		width: 800px;
-	}
+	height: 600px;
+	width: 800px;
 }
 </style>


### PR DESCRIPTION
## Proposed changes

Clicking / opening the popup would cause it to be thin on some browsers. This is fixed by applying a minimum width to the parent to ensure it doesn't fallback onto it's [default minimum size](https://source.chromium.org/chromium/chromium/src/+/main:chrome/browser/ui/views/extensions/extension_popup.h;l=57). It has been tested on various browsers (Chrome, Firefox, Brave, Opera, Vivaldi).  
See the images below for some comparisons.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Note: Firefox does not have any screenshots because it did not seem to have this issue. It did however get checked along with these other browsers to make sure it still worked as intended.

Chrome:
<img src="https://github.com/SevenTV/Extension/assets/29018740/1adb31cf-8876-4858-a01d-1005a51e1c1e" height="400"/> <img src="https://github.com/SevenTV/Extension/assets/29018740/7536e178-d081-4ac9-97cc-5b528cc21733" height="400"/>

Brave:
<img src="https://github.com/SevenTV/Extension/assets/29018740/5c3ed04a-96ee-4d6e-b9e5-9939d78d2626" height="400"/> <img src="https://github.com/SevenTV/Extension/assets/29018740/6f0c22fa-70b5-4ed9-aa65-415677233900" height="400"/>

Opera:
<img src="https://github.com/SevenTV/Extension/assets/29018740/c0f07bdc-e54a-4980-b24c-a4295ddf9d7f" height="400"/> <img src="https://github.com/SevenTV/Extension/assets/29018740/73f71c76-3863-4d72-b85a-898983d4bb62" height="400"/>

Vivaldi:
<img src="https://github.com/SevenTV/Extension/assets/29018740/a9ca3141-dcb8-469a-ba91-d9b9595e5727" height="400"/> <img src="https://github.com/SevenTV/Extension/assets/29018740/6f1f9111-ac72-47ad-a723-3be3006c6e5a" height="400"/>

