### PR TITLE
fix(twitch): load chat history

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -20,6 +20,7 @@
 -   Fixed an issue where replies in threads could not be selected
 -   Fixed an issue where switching the selected emote-set would not be detected
 -   Fixed an issue where the emote menu button did not appear on Kick
+-   Fixed an issue which sometimes caused old messages to not appear
 
 ### 3.0.16.1000
 

--- a/src/site/twitch.tv/modules/chat/ChatController.vue
+++ b/src/site/twitch.tv/modules/chat/ChatController.vue
@@ -264,36 +264,46 @@ if (a instanceof ObserverPromise) {
 const messageBufferComponent = ref<Twitch.MessageBufferComponent | null>(null);
 const messageBufferComponentDbc = refDebounced(messageBufferComponent, 100);
 
+const isLoadingHistoricalMessages = ref(true);
+watch(isLoadingHistoricalMessages, (isLoading) => {
+	const buffer = messageBufferComponent.value?.buffer;
+	if (isLoading || !buffer) return;
+	handleBuffer(buffer);
+});
+
+function handleBuffer(buffer: Twitch.MessageBufferComponent["buffer"]) {
+	if (!buffer.length) return;
+	const historical: ChatMessage[] = [];
+
+	for (const msg of buffer) {
+		const m = new ChatMessage(msg.id);
+
+		// If the message is historical we add it to the array and continue
+		if ((msg as Twitch.ChatMessage).isHistorical || msg.type === MessageType.CONNECTED) {
+			m.historical = true;
+			chatList.value?.onChatMessage(m, msg as Twitch.ChatMessage, false);
+
+			historical.push(m);
+			continue;
+		}
+	}
+
+	messages.displayed = historical.concat(messages.displayed);
+
+	nextTick(() => {
+		// Instantly scroll to the bottom and stop hooking the buffer
+		scroller.scrollToLive(0);
+	});
+}
+
 watch(messageBufferComponentDbc, (msgBuf, old) => {
 	if (old && msgBuf !== old) {
-		unsetPropertyHook(old, "buffer");
 		unsetPropertyHook(old, "blockedUsers");
+		unsetPropertyHook(old, "props");
 	} else if (msgBuf) {
-		definePropertyHook(msgBuf, "buffer", {
-			value(buffer) {
-				if (!buffer.length) return;
-				const historical = [] as ChatMessage[];
-
-				for (const msg of buffer) {
-					const m = new ChatMessage(msg.id);
-
-					// If the message is historical we add it to the array and continue
-					if ((msg as Twitch.ChatMessage).isHistorical || msg.type === MessageType.CONNECTED) {
-						m.historical = true;
-						chatList.value?.onChatMessage(m, msg as Twitch.ChatMessage, false);
-
-						historical.push(m);
-						continue;
-					}
-				}
-
-				messages.displayed = historical.concat(messages.displayed);
-
-				nextTick(() => {
-					// Instantly scroll to the bottom and stop hooking the buffer
-					scroller.scrollToLive(0);
-					unsetPropertyHook(msgBuf, "buffer");
-				});
+		definePropertyHook(msgBuf, "props", {
+			value(props) {
+				isLoadingHistoricalMessages.value = props.isLoadingHistoricalMessages;
 			},
 		});
 


### PR DESCRIPTION
## Proposed changes

When opening up a stream, historic messages would not always display whenever the chat was loaded in. If the chat module was loaded before the historic messages were loaded in, it would not have access to them and thus end up not rendering any. This is however fixed by simply rendering after they have been loaded in.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

--
