### PR TITLE
refactor(twitch): remove hide React button option

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -22,6 +22,7 @@
 -   Fixed an issue where the emote menu button did not appear on Kick
 -   Fixed an issue which sometimes caused old messages to not appear
 -   Sort emotes alphabetically with tab auto-completion on Kick
+-   Removed option to hide the React button on Twitch
 
 ### 3.0.16.1000
 

--- a/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
+++ b/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
@@ -75,12 +75,6 @@ export const config = [
 		defaultValue: false,
 	}),
 	// Main page elements (Twitch Features)
-	declareConfig("layout.hide_react_buttons", "TOGGLE", {
-		path: ["Site Layout", "Twitch Features"],
-		label: "Hide React Buttons",
-		hint: "If checked, the 'React' buttons will be hidden",
-		defaultValue: false,
-	}),
 	declareConfig("layout.hide_bits_buttons", "TOGGLE", {
 		path: ["Site Layout", "Twitch Features"],
 		label: "Hide Bits Buttons",
@@ -168,13 +162,6 @@ export const config = [
 .seventv-hide-stream-chat-bar {
 	button[data-a-target="right-column__toggle-collapse-btn"],
 	div[class$="stream-chat-header"] {
-		display: none !important;
-	}
-}
-
-.seventv-hide-react-buttons {
-	div[class$="theatre-social-panel"] > div:first-child,
-	div[data-target="channel-header-right"] > div:first-child {
 		display: none !important;
 	}
 }

--- a/src/site/twitch.tv/modules/hidden-elements/hiddenElements.ts
+++ b/src/site/twitch.tv/modules/hidden-elements/hiddenElements.ts
@@ -4,7 +4,6 @@ import { useConfig } from "@/composable/useSettings";
 const hideLeaderboard = useConfig<boolean>("layout.hide_channel_leaderboard");
 const hideButtonsBelowChatbox = useConfig<boolean>("layout.hide_buttons_below_chatbox");
 const hideStreamChatBar = useConfig<boolean>("layout.hide_stream_chat_bar");
-const hideReactButtons = useConfig<boolean>("layout.hide_react_buttons");
 const hideBitsButtons = useConfig<boolean>("layout.hide_bits_buttons");
 const hideHypeChatButton = useConfig<boolean>("layout.hide_hype_chat_button");
 const hideTopBarOfStream = useConfig<boolean>("layout.hide_top_bar_of_stream");
@@ -27,7 +26,6 @@ export const hiddenElementSettings: Array<{ class: string; isHidden: Ref<boolean
 	{ class: "seventv-hide-leaderboard", isHidden: hideLeaderboard },
 	{ class: "seventv-hide-buttons-below-chatbox", isHidden: hideButtonsBelowChatbox },
 	{ class: "seventv-hide-stream-chat-bar", isHidden: hideStreamChatBar },
-	{ class: "seventv-hide-react-buttons", isHidden: hideReactButtons },
 	{ class: "seventv-hide-bits-buttons", isHidden: hideBitsButtons },
 	{ class: "seventv-hide-hype-chat-button", isHidden: hideHypeChatButton },
 	{ class: "seventv-hide-top-bar-of-stream", isHidden: hideTopBarOfStream },


### PR DESCRIPTION
## Proposed changes

Twitch seems to have remove the "React" feature which caused some metadata buttons to break. This PR simply removes the option to hide the button.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

--
