### PR TITLE
fix(twitch/chat): low trust / returning user highlight

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -24,6 +24,10 @@
 -   Sort emotes alphabetically with tab auto-completion on Kick
 -   Removed option to hide the React button on Twitch
 -   Added emote support for introduction & watch streak messages.
+-   Fixed an issue that caused suspicious user highlights to not persist
+-   Fixed an issue that caused returning users to not be highlighted
+-   Added an option to show raider highlights
+-   Added an option to show returning user highlights
 
 ### 3.0.16.1000
 

--- a/src/common/chat/ChatMessage.ts
+++ b/src/common/chat/ChatMessage.ts
@@ -20,6 +20,7 @@ export class ChatMessage<C extends ComponentFactory = ComponentFactory> {
 	public deliveryState: MessageDeliveryState = "IDLE";
 	public timestamp = 0;
 	public historical = false;
+	public first = false;
 	public moderation: ChatMessageModeration = {
 		deleted: false,
 		banned: false,
@@ -225,4 +226,20 @@ export interface RichEmbed {
 	};
 	thumbnail_url: string;
 	request_url: string;
+}
+
+export interface LowTrustUserProperties {
+	banEvasion: {
+		likelihood: "LIKELY" | "UNLIKELY" | "POSSIBLE";
+		evaluatedAt: string | null;
+	};
+	channelSharedBansUpdatedAt: string | null;
+	id: string;
+	sharedBanChannels: string[];
+	treatment: {
+		type: "ACTIVE_MONITORING" | "RESTRICTED" | "NONE";
+		updatedAt: string | null;
+		updatedBy: string | null;
+	};
+	types: string[];
 }

--- a/src/composable/chat/useChatMessages.ts
+++ b/src/composable/chat/useChatMessages.ts
@@ -1,6 +1,6 @@
 import { nextTick, reactive, toRef, watch } from "vue";
 import { useTimeoutFn } from "@vueuse/core";
-import { ChatMessage, ChatMessageModeration, ChatUser } from "@/common/chat/ChatMessage";
+import { ChatMessage, ChatMessageModeration, ChatUser, LowTrustUserProperties } from "@/common/chat/ChatMessage";
 import { useChatScroller } from "./useChatScroller";
 import { ChannelContext } from "../channel/useChannelContext";
 import { useConfig } from "../useSettings";
@@ -21,6 +21,7 @@ interface ChatMessages {
 		victim: ChatUser;
 		mod: ChatMessageModeration;
 	}[];
+	lowTrustUsers: Record<string, LowTrustUserProperties>;
 	chatters: Record<string, ChatUser>;
 	chattersByUsername: Record<string, ChatUser>;
 	overflowLimit: number;
@@ -46,6 +47,7 @@ export function useChatMessages(ctx: ChannelContext) {
 			displayedByUser: {} as Record<string, Record<string, ChatMessage>>,
 			awaited: new Map<string, (v: ChatMessage) => void>(),
 			buffer: [] as ChatMessage[],
+			lowTrustUsers: {} as Record<string, LowTrustUserProperties>,
 			moderated: [] as {
 				id: symbol;
 				messages: ChatMessage[];
@@ -292,6 +294,7 @@ export function useChatMessages(ctx: ChannelContext) {
 		handlers: data.twitchHandlers,
 		chatters: toRef(data, "chatters"),
 		chattersByUsername: toRef(data, "chattersByUsername"),
+		lowTrustUsers: toRef(data, "lowTrustUsers"),
 		moderated: toRef(data, "moderated"),
 		sendMessage: toRef(data, "sendMessage"),
 		find,

--- a/src/composable/usePubSub.ts
+++ b/src/composable/usePubSub.ts
@@ -15,11 +15,11 @@ definePropertyHook(
 
 			client.value = v;
 
-			definePropertyHook(client.value.connection, "socket", {
+			definePropertyHook(client.value, "connection", {
 				value(v) {
-					if (!v || !v.socket) return;
+					if (!v || !v.socket || !v.socket.socket) return;
 
-					socket.value = v.socket;
+					socket.value = v.socket.socket;
 				},
 			});
 		},
@@ -75,12 +75,20 @@ export namespace PubSubMessageData {
 			id: string;
 			low_trust_id: string;
 			channel_id: string;
-			sender: Twitch.ChatUser;
-			evaluated_at: string;
+			sender?: {
+				login: string;
+				display_name: string;
+				chat_color: string;
+			};
 			updated_at: string;
-			ban_evasion_evaluation: string;
-			treatment: string;
-			updated_by: Twitch.ChatUser;
+			treatment: "ACTIVE_MONITORING" | "RESTRICTED" | "NONE";
+			evaluated_at: string;
+			ban_evasion_evaluation: "LIKELY" | "UNLIKELY" | "POSSIBLE";
+			updated_by: {
+				id: string;
+				login: string;
+				display_name: string;
+			};
 			shared_ban_channel_ids: string[];
 			types: string[];
 		};
@@ -90,6 +98,23 @@ export namespace PubSubMessageData {
 		};
 		message_id: string;
 		sent_at: string;
+	}
+
+	export interface LowTrustUserTreatmentUpdate {
+		low_trust_id: string;
+		channel_id: string;
+		updated_by: {
+			id: string;
+			login: string;
+			display_name: string;
+		};
+		updated_at: string;
+		target_user_id: string;
+		target_user: string;
+		treatment: "ACTIVE_MONITORING" | "RESTRICTED" | "NO_TREATMENT";
+		types: string[];
+		ban_evasion_evaluation: "LIKELY" | "UNLIKELY" | "POSSIBLE";
+		evaluated_at: string;
 	}
 
 	export interface ModAction {
@@ -129,5 +154,20 @@ export namespace PubSubMessageData {
 		thumbnail_url: string;
 		request_url: string;
 		message_id: string;
+	}
+
+	export interface ChatHighlight {
+		msg_id: string;
+		highlights: (
+			| {
+					type: "raider";
+					source_channel_id: string;
+					seconds_since_event: number;
+			  }
+			| {
+					type: "returning_chatter";
+					source_channel_id: string;
+			  }
+		)[];
 	}
 }

--- a/src/site/twitch.tv/modules/chat/ChatList.vue
+++ b/src/site/twitch.tv/modules/chat/ChatList.vue
@@ -74,6 +74,7 @@ const showSelfHighlights = useConfig<boolean>("highlights.basic.self");
 const shouldPlaySoundOnMention = useConfig<boolean>("highlights.basic.mention_sound");
 const shouldFlashTitleOnHighlight = useConfig<boolean>("highlights.basic.mention_title_flash");
 const showRestrictedLowTrustUser = useConfig<boolean>("highlights.basic.restricted_low_trust_user");
+const showMonitoredLowTrustUser = useConfig<boolean>("highlights.basic.monitored_low_trust_user");
 
 const messageHandler = toRef(props, "messageHandler");
 const list = toRef(props, "list");
@@ -199,14 +200,21 @@ function onChatMessage(msg: ChatMessage, msgData: Twitch.AnyMessage, shouldRende
 
 	if (IsDisplayableMessage(msgData)) {
 		msg.body = (msgData.messageBody ?? msgData.message?.messageBody ?? "").replace("\n", " ");
+		msg.first = msgData.isFirstMsg;
 
 		if (typeof msgData.nonce === "string") msg.setNonce(msgData.nonce);
 
 		// assign highlight
 		if (msgData.isFirstMsg && showFirstTimeChatter.value) {
 			msg.setHighlight("#c832c8", "First Message");
-		} else if (msgData.isReturningChatter) {
-			msg.setHighlight("#3296e6", "Returning Chatter");
+		}
+
+		if (msg.author) {
+			const lowTrust = messages.lowTrustUsers[msg.author.id];
+
+			if (lowTrust && lowTrust.treatment.type === "ACTIVE_MONITORING" && showMonitoredLowTrustUser.value) {
+				msg.setHighlight("#ff7d00", "Monitored Suspicious User");
+			}
 		}
 
 		// assign parent message data

--- a/src/site/twitch.tv/modules/chat/ChatList.vue
+++ b/src/site/twitch.tv/modules/chat/ChatList.vue
@@ -226,6 +226,14 @@ function onChatMessage(msg: ChatMessage, msgData: Twitch.AnyMessage, shouldRende
 							displayName: msgData.reply.parentDisplayName,
 					  }
 					: null;
+			const parentMsgThread =
+				msgData.reply && msgData.reply.threadParentMsgId && msgData.reply.threadParentUserLogin
+					? {
+							deleted: msgData.reply.threadParentDeleted,
+							id: msgData.reply.threadParentMsgId,
+							login: msgData.reply.threadParentUserLogin,
+					  }
+					: null;
 
 			msg.parent = {
 				id: msgData.reply.parentMsgId,
@@ -233,14 +241,7 @@ function onChatMessage(msg: ChatMessage, msgData: Twitch.AnyMessage, shouldRende
 				deleted: msgData.reply.parentDeleted,
 				body: msgData.reply.parentMessageBody,
 				author: parentMsgAuthor,
-				thread:
-					msgData.reply && msgData.reply.threadParentMsgId && msgData.reply.threadParentUserLogin
-						? {
-								deleted: msgData.reply.threadParentDeleted,
-								id: msgData.reply.threadParentMsgId,
-								login: msgData.reply.threadParentUserLogin,
-						  }
-						: null,
+				thread: parentMsgThread,
 			};
 
 			// Highlight as a reply to the actor

--- a/src/site/twitch.tv/modules/chat/ChatModule.vue
+++ b/src/site/twitch.tv/modules/chat/ChatModule.vue
@@ -404,6 +404,18 @@ export const config = [
 		hint: "Whether or not to highlight users who are a restricted suspicious user",
 		defaultValue: true,
 	}),
+	declareConfig<boolean>("highlights.basic.returning_chatter", "TOGGLE", {
+		path: ["Highlights", "Built-In"],
+		label: "Show Returning Chatters (Moderator only)",
+		hint: "Whether or not to highlight users who have returned",
+		defaultValue: false,
+	}),
+	declareConfig<boolean>("highlights.basic.raider", "TOGGLE", {
+		path: ["Highlights", "Built-In"],
+		label: "Show Raiders (Moderator only)",
+		hint: "Whether or not to highlight users who are part of a raid",
+		defaultValue: true,
+	}),
 	declareConfig<boolean>("highlights.basic.first_time_chatter", "TOGGLE", {
 		path: ["Highlights", "Built-In"],
 		label: "Show First-Time Chatter Highlights",

--- a/src/site/twitch.tv/modules/chat/components/tray/ChatTray.ts
+++ b/src/site/twitch.tv/modules/chat/components/tray/ChatTray.ts
@@ -51,7 +51,7 @@ function getReplyTray(props: TrayProps<"Reply">): Twitch.ChatTray<"Reply"> {
 		sendButtonOverride: "reply",
 		disableBits: true,
 		disablePaidPinnedChat: true,
-		disableChat: props.deleted,
+		disableChat: props.deleted || props.thread?.deleted,
 		sendMessageHandler: {
 			type: "reply",
 			additionalMetadata: {


### PR DESCRIPTION
## Proposed changes

When a suspicious user sent a message after being marked as suspicious, the extension would not persist in marking that user as suspicious after new messages were sent. Along with that, returning users were not being highlighted anymore. 
This is caused by Twitch moving chat highlights to pubsub (instead of tmi) which allowed me to add support for raider highlights as well. Another issue caused the pubsub to not re-add listeners after reconnect. See the images below for examples.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

As explained above, low trust statuses were not persistent. However, after fixing this issue it should now look like this:
(I used the following flow for the examples below)

1. Send a message
2. Send a message that is marked with low trust.
3. Send a message (expected to persist).
4. Update the user low trust treatment to none.
5. Send a message (expected to have no highlight)

![image](https://github.com/SevenTV/Extension/assets/29018740/d233162f-8982-47bc-ace5-4bf6dce61bec)
![image](https://github.com/SevenTV/Extension/assets/29018740/c267f623-abec-4a2f-b7bd-1f583ab2fbcf)

Raiders:

![image](https://github.com/SevenTV/Extension/assets/29018740/979168a3-31f8-4c3b-bc58-fb83930116e9)
![image](https://github.com/SevenTV/Extension/assets/29018740/fb1584bf-24e2-4e5d-970a-422ef61ce92f)

![image](https://github.com/SevenTV/Extension/assets/29018740/318cc477-145d-4519-b709-16b94e44f856)
![image](https://github.com/SevenTV/Extension/assets/29018740/355c828f-4cd1-4933-99c7-bfa7234b0786)

Returning chatters:

![image](https://github.com/SevenTV/Extension/assets/29018740/5d6ba22e-9728-42b1-994d-c2d991372889)
![image](https://github.com/SevenTV/Extension/assets/29018740/8fa826c4-f387-4700-bad9-441efb5b8911)


