### PR TITLE
fix(twitch): display logins with international display names

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -28,6 +28,7 @@
 -   Fixed an issue that caused returning users to not be highlighted
 -   Added an option to show raider highlights
 -   Added an option to show returning user highlights
+-   Fixed an issue that caused international names to not always display logins.
 
 ### 3.0.16.1000
 

--- a/src/app/chat/UserCard.vue
+++ b/src/app/chat/UserCard.vue
@@ -181,11 +181,12 @@ const data = reactive({
 		id: props.target.id,
 		username: props.target.username,
 		displayName: props.target.displayName,
+		intl: props.target.intl,
+		color: props.target.color,
 		bannerURL: "",
 		avatarURL: "",
 		createdAt: "",
 		isModerator: false,
-		color: "",
 		badges: [] as SevenTV.Cosmetic<"BADGE">[],
 		relationship: {
 			followedAt: "",
@@ -309,6 +310,7 @@ function addModComment(e: TwTypeModComment): void {
 		username: e.author.login,
 		displayName: e.author.displayName,
 		color: e.author.chatColor,
+		intl: e.author.login !== e.author.displayName.toLowerCase(),
 	});
 	m.setTimestamp(Date.parse(e.timestamp));
 	m.body = e.text;
@@ -419,6 +421,7 @@ watchEffect(async () => {
 				data.targetUser.id = resp.data.targetUser.id;
 				data.targetUser.username = resp.data.targetUser.login;
 				data.targetUser.displayName = resp.data.targetUser.displayName;
+				data.targetUser.intl = resp.data.targetUser.login !== resp.data.targetUser.displayName.toLowerCase();
 				data.targetUser.avatarURL = resp.data.targetUser.profileImageURL;
 				data.targetUser.bannerURL = resp.data.targetUser.bannerImageURL ?? "";
 				data.targetUser.color = resp.data.targetUser.chatColor;

--- a/src/app/chat/UserCard.vue
+++ b/src/app/chat/UserCard.vue
@@ -424,7 +424,7 @@ watchEffect(async () => {
 				data.targetUser.intl = resp.data.targetUser.login !== resp.data.targetUser.displayName.toLowerCase();
 				data.targetUser.avatarURL = resp.data.targetUser.profileImageURL;
 				data.targetUser.bannerURL = resp.data.targetUser.bannerImageURL ?? "";
-				data.targetUser.color = resp.data.targetUser.chatColor;
+				data.targetUser.color = resp.data.targetUser.chatColor ?? props.target.color;
 				data.targetUser.relationship.followedAt = formatDateToString(
 					resp.data.targetUser.relationship?.followedAt,
 				);

--- a/src/site/twitch.tv/modules/chat-vod/ChatVod.vue
+++ b/src/site/twitch.tv/modules/chat-vod/ChatVod.vue
@@ -201,11 +201,14 @@ function createMessageComponentRef(data: CommentData) {
 	const msg = new ChatMessage(data.messageContext.comment.id);
 
 	if (data.messageContext.author) {
+		const isIntl = data.messageContext.author.name !== data.messageContext.author.displayName.toLowerCase();
+
 		msg.setAuthor({
 			id: data.messageContext.author.id,
 			username: data.messageContext.author.name ?? "",
 			displayName: data.messageContext.author.displayName ?? "",
 			color: msgData.message.userColor,
+			intl: isIntl,
 		});
 
 		msg.badges = msgData.userBadges;

--- a/src/site/twitch.tv/modules/chat/ChatList.vue
+++ b/src/site/twitch.tv/modules/chat/ChatList.vue
@@ -177,6 +177,7 @@ function onChatMessage(msg: ChatMessage, msgData: Twitch.AnyMessage, shouldRende
 				id: authorData.userID,
 				username: authorData.userLogin ?? (authorData.userDisplayName ?? authorData.displayName)?.toLowerCase(),
 				displayName: authorData.userDisplayName ?? authorData.displayName ?? authorData.userLogin,
+				intl: authorData.isIntl,
 				color,
 			},
 		);


### PR DESCRIPTION
## Proposed changes

Fixed an issue causing messages to not immediately display logins if the user has an international display name. Along with that, the user cards now also display their logins.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Before:

https://github.com/SevenTV/Extension/assets/29018740/9ae68eda-ac37-4038-a517-149c538bce4f

After:

https://github.com/SevenTV/Extension/assets/29018740/68177380-77c8-4e67-a005-4bcec037ed62

Before:

![image](https://github.com/SevenTV/Extension/assets/29018740/d3bddc0f-1065-42bc-a073-dff6a252c1ad)

After:

![image](https://github.com/SevenTV/Extension/assets/29018740/b15cbc41-e2be-49f7-bbc7-a55174b2eddd)

