### PR TITLE
fix: hosted mode fallback

### DIFF
--- a/src/site/site.app.ts
+++ b/src/site/site.app.ts
@@ -62,6 +62,7 @@ const app = createApp({
 app.provide("app-id", appID);
 
 const extensionOrigin = scr?.getAttribute("extension_origin") ?? "";
+seventv.hosted ??= seventv.remote;
 app.provide(
 	SITE_WORKER_URL,
 	seventv.hosted ? seventv.host_manifest?.worker_file ?? null : null ?? scr?.getAttribute("worker_url"),

--- a/src/types/app.d.ts
+++ b/src/types/app.d.ts
@@ -5,6 +5,7 @@ declare interface SeventvGlobalScope {
 		stylesheet_file: string;
 		index_file: string;
 	};
+	remote?: boolean;
 	hosted?: boolean;
 }
 


### PR DESCRIPTION
## Proposed changes

A minor change made in https://github.com/SevenTV/Extension/commit/4c0f3b97d89f0f1166af50710f3a50ba4075309f caused the builds deployed after `3.0.15` to use the `hosted` property as opposed to `remote` exposed on the `seventv` global. Since the older build (3.0.9) still exposes `remote` it causes `hosted` to never be defined. Nightly builds are not affect because their latest store build was version `3.0.15.1000`.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

--
