### PR TITLE
fix(tokenizer): empty emote

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -30,6 +30,7 @@
 -   Added an option to show returning user highlights
 -   Fixed an issue that caused international names to not always display logins
 -   Fixed an issue that caused Twitch VODs to not load emotes
+-   Fixed an issue that caused certain words to not display in chat
 
 ### 3.0.16.1000
 

--- a/src/common/Tokenize.ts
+++ b/src/common/Tokenize.ts
@@ -8,7 +8,15 @@ export function tokenize(opt: TokenizeOptions) {
 	const tokens = [] as AnyToken[];
 
 	const textParts = opt.body.split(" ");
-	const getEmote = (name: string) => opt.localEmoteMap?.[name] ?? opt.emoteMap[name];
+	const getEmote = (name: string) => {
+		if (opt.localEmoteMap?.[name] && Object.hasOwn(opt.localEmoteMap, name)) {
+			return opt.localEmoteMap[name];
+		}
+
+		if (opt.emoteMap[name] && Object.hasOwn(opt.emoteMap, name)) {
+			return opt.emoteMap[name];
+		}
+	};
 	const showModifiers = opt.showModifiers;
 
 	let cursor = -1;

--- a/src/common/chat/Tokenizer.ts
+++ b/src/common/chat/Tokenizer.ts
@@ -22,7 +22,15 @@ export class Tokenizer {
 		const tokens = [] as AnyToken[];
 
 		const textParts = this.msg.body.split(" ");
-		const getEmote = (name: string) => opt.localEmoteMap?.[name] ?? opt.emoteMap[name];
+		const getEmote = (name: string) => {
+			if (opt.localEmoteMap?.[name] && Object.hasOwn(opt.localEmoteMap, name)) {
+				return opt.localEmoteMap[name];
+			}
+
+			if (opt.emoteMap[name] && Object.hasOwn(opt.emoteMap, name)) {
+				return opt.emoteMap[name];
+			}
+		};
 		const showModifiers = opt.showModifiers;
 
 		let cursor = -1;
@@ -43,7 +51,8 @@ export class Tokenizer {
 			const maybeEmote = getEmote(part);
 			const nextEmote = getEmote(textParts[textParts.indexOf(part) + 1]);
 			const prevEmote = getEmote(textParts[textParts.indexOf(part) - 1]);
-			const maybeMention = !!opt.chatterMap[part.toLowerCase()];
+			const maybeMention =
+				opt.chatterMap[part.toLowerCase()] && Object.hasOwn(opt.chatterMap, part.toLowerCase());
 
 			if (maybeEmote) {
 				// handle zero width overlaying


### PR DESCRIPTION
## Proposed changes

Using an emote name that contains property keys of an object prototype causes the Tokenizer to resolve to that property instead of an actual emote. E.g. using the text `constructor` or `__proto__` will result in an empty "emote". The same applies to mentions. See the images below for examples.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Before:

![image](https://github.com/SevenTV/Extension/assets/29018740/fb883850-ad3d-46c2-8960-9f1e32c8d3f9)

After:

![image](https://github.com/SevenTV/Extension/assets/29018740/30d0cbfb-d1d3-42e4-bc13-3ce63bedde1b)

