### PR TITLE
fix: Fixed an issue where twitch emotes were larger after hover

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,3 +1,7 @@
+### 3.1.1.2000
+
+-   Fixed an issue where twitch emotes were displayed larger after hovering over them
+
 ### 3.1.0.3000
 
 -   Fixed video player stats not showing

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Improve your viewing experience on Twitch & YouTube with new features, emotes, vanity and performance.",
 	"private": true,
 	"version": "3.1.1",
-	"dev_version": "1.0",
+	"dev_version": "2.0",
 	"scripts": {
 		"start": "NODE_ENV=dev yarn build:dev && NODE_ENV=dev vite --mode dev",
 		"build:section:app": "vite build --config vite.config.mts",

--- a/src/common/Image.ts
+++ b/src/common/Image.ts
@@ -1,7 +1,7 @@
 import { useUserAgent } from "@/composable/useUserAgent";
 
 const layout = {
-	PLATFORM: [1, 2, 3],
+	PLATFORM: [1, 2, 4],
 	"7TV": [1, 2, 3, 4],
 	FFZ: [1, 2, 4],
 	BTTV: [1, 2, 4],

--- a/src/common/Transform.ts
+++ b/src/common/Transform.ts
@@ -69,10 +69,6 @@ export function convertTwitchEmote(
 					format: "PNG",
 				},
 				{
-					name: "3.0",
-					format: "PNG",
-				},
-				{
 					name: "4.0",
 					format: "PNG",
 				},


### PR DESCRIPTION
## Proposed changes

After hovering over a twitch emote (global or sub) at 1x scaling this emote was displayed larger than normal in chat afterwards (37x37 instead of the usual 28x28). This happened until the page was refreshed.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Reason for bug was using 1x, 2x and 3x for twitch srcset. 3x and 4x for twitch are both 112x112 though.
Changing to 1x, 2x and 4x and adjusting the twitch emote converter fixed this problem.

old behaviour: 

https://github.com/SevenTV/Extension/assets/103491518/e26f6f04-5d81-4df8-bb0f-64ac44aee47a

new behaviour:

https://github.com/SevenTV/Extension/assets/103491518/76f381bf-f1c9-49ef-9511-67493eb12d75

