### PR TITLE
feat: Added option to hide 7TV badges in chat

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,6 +1,7 @@
 ### 3.1.1.2000
 
 -   Fixed an issue where twitch emotes were displayed larger after hovering over them
+-   Added option to hide 7TV badges from chat
 
 ### 3.1.0.3000
 

--- a/src/app/chat/UserTag.vue
+++ b/src/app/chat/UserTag.vue
@@ -79,6 +79,7 @@ const ctx = useChannelContext();
 const properties = useChatProperties(ctx);
 const cosmetics = useCosmetics(props.user.id);
 const shouldRenderPaint = useConfig("vanity.nametag_paints");
+const shouldRender7tvBadges = useConfig("vanity.7tv_Badges");
 const betterUserCardEnabled = useConfig("chat.user_card");
 const twitchBadges = ref<Twitch.ChatBadge[]>([]);
 const twitchBadgeSets = toRef(properties, "twitchBadgeSets");
@@ -133,7 +134,7 @@ const stop = watch(
 		}
 
 		paint.value = shouldRenderPaint.value && paints && paints.size ? paints.values().next().value : null;
-		activeBadges.value = [...badges.values()];
+		activeBadges.value = shouldRender7tvBadges.value && badges && badges.size ? [...badges.values()] : [];
 	},
 	{ immediate: true },
 );

--- a/src/site/twitch.tv/modules/chat/ChatModule.vue
+++ b/src/site/twitch.tv/modules/chat/ChatModule.vue
@@ -478,5 +478,11 @@ export const config = [
 		hint: "Whether or not to display nametag paints",
 		defaultValue: true,
 	}),
+	declareConfig<boolean>("vanity.7tv_Badges", "TOGGLE", {
+		path: ["Appearance", "Vanity"],
+		label: "7TV Badges",
+		hint: "Whether or not to display 7TV Badges",
+		defaultValue: true,
+	}),
 ];
 </script>


### PR DESCRIPTION
## Proposed changes

Added option to hide 7TV badges in chat.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

A slider option to show or hide 7TV badges was added in the settings under Appearance -> Vanity. Default setting is show.

Settings:
![Screenshot 2024-06-19 210233](https://github.com/SevenTV/Extension/assets/103491518/60e9fc69-4726-4466-a07a-39d5c68eb6d1)

activated:
![Screenshot 2024-06-19 210325](https://github.com/SevenTV/Extension/assets/103491518/816d8033-6ab0-4f0a-9ec0-123f1d89bd4a)

disbaled:
![Screenshot 2024-06-19 210347](https://github.com/SevenTV/Extension/assets/103491518/7417fe0a-6322-426b-8171-c456f44ca566)

