### PR TITLE
feat: Added option to hide powerups from reward menu

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,6 +1,7 @@
 ### 3.1.1.2000
 
 -   Fixed an issue where twitch emotes were displayed larger after hovering over them
+-   Added option to hide the power-ups reward options from the channel point reward menu
 
 ### 3.1.0.3000
 

--- a/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
+++ b/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
@@ -301,10 +301,17 @@ export const config = [
 }
 
 .seventv-hide-powerups-reward-list {
-	#channel-points-reward-center-body > *:nth-child(1) > *:nth-child(1) > .ZvPWT:nth-child(n+3):nth-child(-n+4){
+	#channel-points-reward-center-body
+		> *:nth-child(1)
+		> *:nth-child(1)
+		> *:nth-child(n + 3):nth-child(-n + 4)
+		> p:nth-of-type(1) {
 		display: none !important;
 	}
-	#channel-points-reward-center-body > *:nth-child(1) > *:nth-child(1) > .reward-list-item:nth-child(n+4):nth-child(-n+7){
+	#channel-points-reward-center-body
+		> *:nth-child(1)
+		> *:nth-child(1)
+		> .reward-list-item:nth-child(n + 4):nth-child(-n + 7) {
 		display: none !important;
 	}
 }

--- a/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
+++ b/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
@@ -155,6 +155,12 @@ export const config = [
 		hint: "If checked, on-screen celebrations will be hidden",
 		defaultValue: false,
 	}),
+	declareConfig("layout.hide_powerups_reward_list", "TOGGLE", {
+		path: ["Site Layout", "Twitch Features"],
+		label: "Hide Power-ups from rewards menu",
+		hint: "If checked, power-ups are hidden from the bits and channel points reward menu",
+		defaultValue: false,
+	}),
 ];
 </script>
 
@@ -290,6 +296,15 @@ export const config = [
 
 .seventv-hide-onscreen-celebrations {
 	div.celebration__overlay {
+		display: none !important;
+	}
+}
+
+.seventv-hide-powerups-reward-list {
+	#channel-points-reward-center-body > *:nth-child(1) > *:nth-child(1) > .ZvPWT:nth-child(n+3):nth-child(-n+4){
+		display: none !important;
+	}
+	#channel-points-reward-center-body > *:nth-child(1) > *:nth-child(1) > .reward-list-item:nth-child(n+4):nth-child(-n+7){
 		display: none !important;
 	}
 }

--- a/src/site/twitch.tv/modules/hidden-elements/hiddenElements.ts
+++ b/src/site/twitch.tv/modules/hidden-elements/hiddenElements.ts
@@ -22,6 +22,7 @@ const hideChatInputBox = useConfig<boolean>("layout.hide_chat_input_box");
 const hidePlayerExtensions = useConfig<boolean>("player.hide_player_extensions");
 const hideChannelPointBalanceButton = useConfig<boolean>("layout.hide_channel_point_balance_button");
 const hideOnscreenCelebrations = useConfig<boolean>("player.hide_onscreen_celebrations");
+const hidePowerUpsRewardList = useConfig<boolean>("layout.hide_powerups_reward_list");
 
 export const hiddenElementSettings: Array<{ class: string; isHidden: Ref<boolean> }> = [
 	{ class: "seventv-hide-leaderboard", isHidden: hideLeaderboard },
@@ -45,4 +46,5 @@ export const hiddenElementSettings: Array<{ class: string; isHidden: Ref<boolean
 	{ class: "seventv-hide-player-ext", isHidden: hidePlayerExtensions },
 	{ class: "seventv-hide-channel-point-balance-button", isHidden: hideChannelPointBalanceButton },
 	{ class: "seventv-hide-onscreen-celebrations", isHidden: hideOnscreenCelebrations },
+	{ class: "seventv-hide-powerups-reward-list", isHidden: hidePowerUpsRewardList },
 ];


### PR DESCRIPTION
## Proposed changes

in the reward menu the options for power ups are now always displayed above all the channel point rewards. To make the menu cleaner an option to hide these power ups should be added.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

A slider option to hide the power ups from the reward menu was added to the settings under Site Layout -> Twitch Features:
![Screenshot 2024-06-19 214442](https://github.com/SevenTV/Extension/assets/103491518/6c62c6a1-96c4-4c06-b4ba-f7e4811a3188)

It was a bit tricky to make sure the right elements get hidden, since all the rewards, power ups and category headlines are on the same level in hierarchy and don't have any classes to make them unique. Furthermore depending on if a challenge or prediction are active an additional div for the category "Challenges and Predictions" can be existent or not (the divs for the actual challenge or prediction are always existing, just the one for the header is optional). With the implementation I chose it should always hide the correct divs regardless of that.

Reward menu with power ups:
![Screenshot 2024-06-19 215252](https://github.com/SevenTV/Extension/assets/103491518/270a7a6a-d90c-423e-9534-f0090d2b2f28)

Reward menu with power ups and active prediction:
![Screenshot 2024-06-19 215357](https://github.com/SevenTV/Extension/assets/103491518/212fd2d0-f2df-449b-b4b7-cb590a55d600)

Reward menu without power ups:
![Screenshot 2024-06-19 215450](https://github.com/SevenTV/Extension/assets/103491518/2a1e242f-d277-4f03-924d-af038d66e92f)

Reward menu without power ups and active prediction:
![Screenshot 2024-06-19 215426](https://github.com/SevenTV/Extension/assets/103491518/61802e87-7c60-4f18-87c9-afb6c31c06ab)


 