### PR TITLE
fix(twitch/vod-chat): vod chat double timestamp

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,6 +1,7 @@
 ### 3.1.1.2000
 
 -   Fixed an issue where twitch emotes were displayed larger after hovering over them
+-   Fixed an issue causing VOD messages to display two timestamps
 
 ### 3.1.0.3000
 

--- a/src/site/twitch.tv/modules/chat-vod/ChatVod.vue
+++ b/src/site/twitch.tv/modules/chat-vod/ChatVod.vue
@@ -111,6 +111,8 @@ definePropertyHook(props.controller.component, "props", {
 		} else {
 			ctx.actor.roles.delete("MODERATOR");
 		}
+
+		properties.showTimestamps = false;
 	},
 });
 


### PR DESCRIPTION
## Proposed changes

Navigating to a VOD will cause the extension to render message timestamps twice. This does not occur when going to a VOD directly by URL. See the images below

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Before:
![Screen_Shot](https://github.com/SevenTV/Extension/assets/29018740/633fe740-b2eb-477c-98dd-c973e1ae1399)

After:
![Screen_Shot](https://github.com/SevenTV/Extension/assets/29018740/e0c08f65-a622-411c-92ab-db9d8ed2a1a9)

