### PR TITLE
Feat: Animated FFZ emote support

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,6 +1,9 @@
-### 3.1.1.2100
+### 3.2.2 1000
 
 -   Added support for animated FFZ emotes
+
+### 3.1.1.2100
+
 -   Fixed an issue where certain hooks would not work properly
 
 ### 3.1.1.2000

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,5 +1,6 @@
 ### 3.1.1.2100
 
+-   Added support for animated FFZ emotes
 -   Fixed an issue where certain hooks would not work properly
 
 ### 3.1.1.2000

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,4 +1,4 @@
-### 3.2.2 1000
+### 3.1.1 3000
 
 -   Added support for animated FFZ emotes
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Improve your viewing experience on Twitch & YouTube with new features, emotes, vanity and performance.",
 	"private": true,
 	"version": "3.1.1",
-	"dev_version": "2.0",
+	"dev_version": "3.0",
 	"scripts": {
 		"start": "NODE_ENV=dev yarn build:dev && NODE_ENV=dev vite --mode dev",
 		"build:section:app": "vite build --config vite.config.mts",

--- a/src/common/Transform.ts
+++ b/src/common/Transform.ts
@@ -232,13 +232,22 @@ export function convertFFZEmote(data: FFZ.Emote): SevenTV.Emote {
 		listed: true,
 		owner: null,
 		host: {
-			url: "//cdn.frankerfacez.com/emote/" + data.id,
-			files: Object.keys(data.urls).map((key) => {
-				return {
-					name: key,
-					format: "PNG",
-				};
-			}),
+			url: data.animated
+				? "//cdn.frankerfacez.com/emote/" + data.id + "/animated"
+				: "//cdn.frankerfacez.com/emote/" + data.id,
+			files: data.animated
+				? Object.keys(data.animated).map((key) => {
+						return {
+							name: key,
+							format: "WEBP",
+						};
+				  })
+				: Object.keys(data.urls).map((key) => {
+						return {
+							name: key,
+							format: "PNG",
+						};
+				  }),
 		},
 	};
 }

--- a/src/types/app.d.ts
+++ b/src/types/app.d.ts
@@ -480,7 +480,7 @@ declare namespace FFZ {
 			display_name: string;
 		} | null;
 		urls: LinkMap;
-		animated: LinkMap;
+		animated?: LinkMap;
 	}
 
 	interface BadgesResponse {

--- a/src/types/app.d.ts
+++ b/src/types/app.d.ts
@@ -480,6 +480,7 @@ declare namespace FFZ {
 			display_name: string;
 		} | null;
 		urls: LinkMap;
+		animated: LinkMap;
 	}
 
 	interface BadgesResponse {


### PR DESCRIPTION
## Proposed changes

Only static FFZ emotes are currently supported by 7TV. For animated emotes only the static version is used, probably because FFZ itself only added support for them rather recently. Because of that 7TV should add support for animated FFZ emotes as well.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The FFZ API has a field "animated" which returns a map of DPI scales to animated emote URLs and is null if the emote is not animated. This field was added to our interface and the transformer adjusted to use the correct url and file dependant on if the emote is animated or not.

Documentation from FFZ API: 
![Screenshot 2024-06-20 203722](https://github.com/SevenTV/Extension/assets/103491518/cf3c548d-6729-416e-b042-254fdac2589a)

