### PR TITLE
fix: ignore composing key events to prevent unintended behavior

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,4 +1,8 @@
-### 3.1.1 3000
+### 3.1.1.3100
+
+-   Fixed an issue where history navigation is accidentally triggered during IME composition
+
+### 3.1.1.3000
 
 -   Added support for animated FFZ emotes
 -   Added option to hide whispers

--- a/src/app/emote-menu/EmoteMenu.vue
+++ b/src/app/emote-menu/EmoteMenu.vue
@@ -138,6 +138,7 @@ onKeyStroke("e", (ev) => {
 
 // Up/Down Arrow iterates providers
 useEventListener("keydown", (ev) => {
+	if (ev.isComposing) return;
 	if (!["ArrowUp", "ArrowDown"].includes(ev.key)) return;
 
 	const cur = Object.keys(visibleProviders).indexOf(activeProvider.value ?? "7TV");

--- a/src/site/kick.com/modules/chat/ChatAutocomplete.vue
+++ b/src/site/kick.com/modules/chat/ChatAutocomplete.vue
@@ -195,6 +195,8 @@ useEventListener(
 	inputEl,
 	"keydown",
 	(ev: KeyboardEvent) => {
+		if (ev.isComposing) return;
+
 		const sel = document.getSelection();
 		if (!sel) return;
 

--- a/src/site/twitch.tv/modules/chat-input/ChatInput.vue
+++ b/src/site/twitch.tv/modules/chat-input/ChatInput.vue
@@ -402,6 +402,8 @@ function resetState() {
 }
 
 function onKeyDown(ev: KeyboardEvent) {
+	if (ev.isComposing) return;
+
 	switch (ev.key) {
 		case "Tab":
 			handleTabPress(ev, isShift.value);

--- a/src/site/twitch.tv/modules/chat-input/ChatInputCarousel.vue
+++ b/src/site/twitch.tv/modules/chat-input/ChatInputCarousel.vue
@@ -73,6 +73,7 @@ useEventListener(
 	"keydown",
 	(ev) => {
 		if (!shouldListenToArrowPresses.value) return;
+		if (ev.isComposing) return;
 
 		if (ev.key === "ArrowLeft") {
 			emit("back", ev);


### PR DESCRIPTION
## Proposed changes

This change fixes an issue where history navigation (up/down arrow key on chat box) was accidentally triggered during IME composition.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

IME is a tool for writing Japanese (and other languages I'm not aware of) where users can select the word they want to enter from the list of words that match the pronounciation given by the user's keystrokes--this process is called composition.
It's pretty common to press arrow key during composition, and that has caused unintended chat history rewinding:

1. Opens up IME
    <img width="334" alt="Screenshot 2024-08-07 at 12 13 07" src="https://github.com/user-attachments/assets/51e5a835-2c8b-4218-9aae-8d357612f4dc">

1. After pressing UP
    <img width="335" alt="Screenshot 2024-08-07 at 12 13 34" src="https://github.com/user-attachments/assets/fc7d82fc-b889-4c56-aebf-59fd7d8cac7f">


