### PR TITLE
Added Hide Stories option + Fixed Options for recommended channels and vieweres also watch

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,7 +1,7 @@
 NODE_ENV=development
-VITE_APP_SITE="http://localhost:4200"
-VITE_APP_API="http://localhost:3100/v3"
-VITE_APP_API_GQL="http://localhost:3000/v3/gql"
-VITE_APP_API_EVENTS="ws://localhost:3700/v3"
-VITE_APP_API_EGVAULT="http://localhost:3444/v1"
-VITE_APP_HOST="http://localhost:8080"
+VITE_APP_SITE="https://7tv.app"
+VITE_APP_API="https://7tv.io/v3"
+VITE_APP_API_GQL="https://7tv.io/v3/gql"
+VITE_APP_API_EVENTS="wss://events.7tv.io/v3"
+VITE_APP_API_EGVAULT="https://egvault.7tv.io/v1"
+VITE_APP_HOST="https://extension.7tv.gg"

--- a/.old.env.dev
+++ b/.old.env.dev
@@ -1,0 +1,7 @@
+NODE_ENV=development
+VITE_APP_SITE="http://localhost:4200"
+VITE_APP_API="http://localhost:3100/v3"
+VITE_APP_API_GQL="http://localhost:3000/v3/gql"
+VITE_APP_API_EVENTS="ws://localhost:3700/v3"
+VITE_APP_API_EGVAULT="http://localhost:3444/v1"
+VITE_APP_HOST="http://localhost:8080"

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -2,6 +2,7 @@
 
 -   Fixed an issue where twitch emotes were displayed larger after hovering over them
 -   Fixed an issue causing VOD messages to display two timestamps
+-   Added option to hide 7TV badges from chat
 
 ### 3.1.0.3000
 

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,3 +1,7 @@
+### 3.1.1.2000
+
+-   Fixed an issue where twitch emotes were displayed larger after hovering over them
+
 ### 3.1.0.3000
 
 -   Fixed video player stats not showing

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,6 +1,7 @@
 ### 3.1.1 3000
 
 -   Added support for animated FFZ emotes
+-   Added option to hide whispers
 
 ### 3.1.1.2100
 

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,8 +1,10 @@
 ### 3.1.1.2000
 
+-   Added option to hide 7TV badges from chat
+-   Added option to hide bits from community button
 -   Fixed an issue where twitch emotes were displayed larger after hovering over them
 -   Fixed an issue causing VOD messages to display two timestamps
--   Added option to hide 7TV badges from chat
+-   Fixed an issue where the chat would keep rendering emotes of the previous channel
 
 ### 3.1.0.3000
 

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -2,6 +2,7 @@
 
 -   Added support for animated FFZ emotes
 -   Added option to hide whispers
+-   Added tooltip to error messages in /search
 
 ### 3.1.1.2100
 

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,3 +1,7 @@
+### 3.1.1 3000
+
+-   Added support for animated FFZ emotes
+
 ### 3.1.1.2100
 
 -   Fixed an issue where certain hooks would not work properly

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,3 +1,7 @@
+### 3.1.1.2100
+
+-   Fixed an issue where certain hooks would not work properly
+
 ### 3.1.1.2000
 
 -   Added option to hide 7TV badges from chat

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,3 +1,8 @@
+### 3.1.1 4000
+
+-   Added option to settings to hide Stories from the sidebar
+-   Fixed settings to hide recommended channels and viewers also watch channels
+
 ### 3.1.1 3000
 
 -   Added support for animated FFZ emotes

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,6 +1,7 @@
 ### 3.1.1.2000
 
 -   Fixed an issue where twitch emotes were displayed larger after hovering over them
+-   Fixed an issue causing VOD messages to display two timestamps
 
 ### 3.1.0.3000
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Improve your viewing experience on Twitch & YouTube with new features, emotes, vanity and performance.",
 	"private": true,
 	"version": "3.1.1",
-	"dev_version": "3.0",
+	"dev_version": "4.0",
 	"scripts": {
 		"start": "NODE_ENV=dev yarn build:dev && NODE_ENV=dev vite --mode dev",
 		"build:section:app": "vite build --config vite.config.mts",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Improve your viewing experience on Twitch & YouTube with new features, emotes, vanity and performance.",
 	"private": true,
 	"version": "3.1.1",
-	"dev_version": "2.0",
+	"dev_version": "3.0",
 	"scripts": {
 		"start": "NODE_ENV=dev yarn build:dev && NODE_ENV=dev vite --mode dev",
 		"build:section:app": "vite build --config vite.config.mts",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Improve your viewing experience on Twitch & YouTube with new features, emotes, vanity and performance.",
 	"private": true,
 	"version": "3.1.1",
-	"dev_version": "1.0",
+	"dev_version": "2.0",
 	"scripts": {
 		"start": "NODE_ENV=dev yarn build:dev && NODE_ENV=dev vite --mode dev",
 		"build:section:app": "vite build --config vite.config.mts",

--- a/src/app/chat/UserTag.vue
+++ b/src/app/chat/UserTag.vue
@@ -79,6 +79,7 @@ const ctx = useChannelContext();
 const properties = useChatProperties(ctx);
 const cosmetics = useCosmetics(props.user.id);
 const shouldRenderPaint = useConfig("vanity.nametag_paints");
+const shouldRender7tvBadges = useConfig("vanity.7tv_Badges");
 const betterUserCardEnabled = useConfig("chat.user_card");
 const twitchBadges = ref<Twitch.ChatBadge[]>([]);
 const twitchBadgeSets = toRef(properties, "twitchBadgeSets");
@@ -133,7 +134,7 @@ const stop = watch(
 		}
 
 		paint.value = shouldRenderPaint.value && paints && paints.size ? paints.values().next().value : null;
-		activeBadges.value = [...badges.values()];
+		activeBadges.value = shouldRender7tvBadges.value && badges && badges.size ? [...badges.values()] : [];
 	},
 	{ immediate: true },
 );

--- a/src/common/Image.ts
+++ b/src/common/Image.ts
@@ -1,7 +1,7 @@
 import { useUserAgent } from "@/composable/useUserAgent";
 
 const layout = {
-	PLATFORM: [1, 2, 3],
+	PLATFORM: [1, 2, 4],
 	"7TV": [1, 2, 3, 4],
 	FFZ: [1, 2, 4],
 	BTTV: [1, 2, 4],

--- a/src/common/ReactHooks.ts
+++ b/src/common/ReactHooks.ts
@@ -306,6 +306,9 @@ export function defineComponentHook<C extends ReactExtended.WritableComponent>(
 				if (options.functionHooks) {
 					for (const [k, f] of Object.entries(options.functionHooks)) {
 						defineFunctionHook(proto, k as keyof C, f);
+						for (const instance of instances) {
+							defineFunctionHook(instance, k as keyof C, f);
+						}
 					}
 				}
 
@@ -412,6 +415,9 @@ export function useComponentHook<C extends ReactExtended.WritableComponent>(
 			for (const k of Object.keys(options.functionHooks)) {
 				if (hook.cls) {
 					unsetPropertyHook(hook.cls.prototype, k as keyof C);
+				}
+				for (const instance of hook.instances) {
+					unsetPropertyHook(instance.component, k as keyof C);
 				}
 			}
 		}

--- a/src/common/Transform.ts
+++ b/src/common/Transform.ts
@@ -69,10 +69,6 @@ export function convertTwitchEmote(
 					format: "PNG",
 				},
 				{
-					name: "3.0",
-					format: "PNG",
-				},
-				{
 					name: "4.0",
 					format: "PNG",
 				},

--- a/src/common/Transform.ts
+++ b/src/common/Transform.ts
@@ -232,13 +232,22 @@ export function convertFFZEmote(data: FFZ.Emote): SevenTV.Emote {
 		listed: true,
 		owner: null,
 		host: {
-			url: "//cdn.frankerfacez.com/emote/" + data.id,
-			files: Object.keys(data.urls).map((key) => {
-				return {
-					name: key,
-					format: "PNG",
-				};
-			}),
+			url: data.animated
+				? "//cdn.frankerfacez.com/emote/" + data.id + "/animated"
+				: "//cdn.frankerfacez.com/emote/" + data.id,
+			files: data.animated
+				? Object.keys(data.animated).map((key) => {
+						return {
+							name: key,
+							format: "WEBP",
+						};
+				  })
+				: Object.keys(data.urls).map((key) => {
+						return {
+							name: key,
+							format: "PNG",
+						};
+				  }),
 		},
 	};
 }

--- a/src/composable/chat/useChatEmotes.ts
+++ b/src/composable/chat/useChatEmotes.ts
@@ -32,7 +32,7 @@ export function useChatEmotes(ctx: ChannelContext) {
 		m.set(ctx, x);
 	}
 
-	function resetProviders() {
+	function reset() {
 		if (!x) return;
 
 		for (const k in x.providers) {
@@ -41,6 +41,12 @@ export function useChatEmotes(ctx: ChannelContext) {
 			for (const k2 in x.providers[k as SevenTV.Provider]) {
 				delete x.providers[k as SevenTV.Provider][k2];
 			}
+		}
+
+		for (const k in x.active) {
+			const ae = x.active[k];
+			if (ae.provider === "EMOJI") continue;
+			delete x.active[k];
 		}
 	}
 
@@ -75,7 +81,7 @@ export function useChatEmotes(ctx: ChannelContext) {
 		sets: x.sets,
 		emojis: x.emojis,
 		providers: x.providers,
-		resetProviders,
+		reset,
 		byProvider,
 		find,
 	});

--- a/src/composable/useActor.ts
+++ b/src/composable/useActor.ts
@@ -10,6 +10,7 @@ class ActorContext {
 	user: SevenTV.User | null = null;
 	sub: SubscriptionResponse | null = null;
 	token = useConfig<string>("app.7tv.token") as unknown as string;
+	editAnySet = false;
 
 	platform: Platform | null = null;
 	platformUserID: string | null = null;

--- a/src/composable/useSetMutation.ts
+++ b/src/composable/useSetMutation.ts
@@ -48,7 +48,8 @@ export function useSetMutation(setID?: string): SetMutation {
 	const canEditIfLoggedIn = computed(() => {
 		if (!actor.user) return false;
 		if (ctx.id == actor.platformUserID) return true;
-		return (ctx.user?.editors ?? []).some((e) => e.id == actor.user?.id);
+		if ((ctx.user?.editors ?? []).some((e) => e.id == actor.user?.id)) return true;
+		return actor.editAnySet;
 	});
 
 	const canEditSet = computed(() => {

--- a/src/composable/useTooltip.ts
+++ b/src/composable/useTooltip.ts
@@ -22,7 +22,7 @@ export function useTooltip(content?: string | Component, props?: Record<string, 
 		if (!el) return;
 
 		// Set the content, this is necessary to calculate the tooltip's positioning
-		if (content) {
+		if (content !== undefined) {
 			tooltip.content = typeof content === "string" ? content : markRaw(content);
 			tooltip.contentProps = props ?? {};
 		}

--- a/src/site/twitch.tv/modules/chat-vod/ChatVod.vue
+++ b/src/site/twitch.tv/modules/chat-vod/ChatVod.vue
@@ -111,6 +111,8 @@ definePropertyHook(props.controller.component, "props", {
 		} else {
 			ctx.actor.roles.delete("MODERATOR");
 		}
+
+		properties.showTimestamps = false;
 	},
 });
 

--- a/src/site/twitch.tv/modules/chat/ChatController.vue
+++ b/src/site/twitch.tv/modules/chat/ChatController.vue
@@ -328,7 +328,7 @@ watch(
 		messages.clear();
 		scroller.unpause();
 
-		nextTick(() => emotes.resetProviders());
+		nextTick(emotes.reset);
 	},
 	{ immediate: true },
 );

--- a/src/site/twitch.tv/modules/chat/ChatModule.vue
+++ b/src/site/twitch.tv/modules/chat/ChatModule.vue
@@ -478,5 +478,11 @@ export const config = [
 		hint: "Whether or not to display nametag paints",
 		defaultValue: true,
 	}),
+	declareConfig<boolean>("vanity.7tv_Badges", "TOGGLE", {
+		path: ["Appearance", "Vanity"],
+		label: "7TV Badges",
+		hint: "Whether or not to display 7TV Badges",
+		defaultValue: true,
+	}),
 ];
 </script>

--- a/src/site/twitch.tv/modules/chat/ChatModule.vue
+++ b/src/site/twitch.tv/modules/chat/ChatModule.vue
@@ -501,8 +501,8 @@ export const config = [
 		defaultValue: true,
 	}),
 	declareConfig("chat.hide_bits_balance", "TOGGLE", {
-		label: "Hide Bits Balance",
-		hint: "Hide the bits balance in the chat.",
+		label: "Hide Bits From Community Points Button",
+		hint: "Hide the bits balance from the community points button under the chatbox",
 		path: ["Chat", "Style"],
 		defaultValue: false,
 	}),

--- a/src/site/twitch.tv/modules/chat/ChatModule.vue
+++ b/src/site/twitch.tv/modules/chat/ChatModule.vue
@@ -78,6 +78,22 @@ const chatEvents = useComponentHook<Twitch.ChatEventComponent>({
 	predicate: (n) => n.onClearChatEvent,
 });
 
+const hideBitsBalance = useConfig<boolean>("chat.hide_bits_balance");
+useComponentHook<Twitch.ChatCommunityPointsButtonComponent>(
+	{
+		childSelector: ".community-points-summary",
+		predicate: (el) => el.shouldShowBitsBalance,
+	},
+	{
+		functionHooks: {
+			shouldShowBitsBalance(this, old) {
+				if (hideBitsBalance.value) return false;
+				return old.call(this);
+			},
+		},
+	},
+);
+
 const isHookable = ref(false);
 const isHookableDbc = refDebounced(isHookable, 200);
 
@@ -483,6 +499,12 @@ export const config = [
 		label: "7TV Badges",
 		hint: "Whether or not to display 7TV Badges",
 		defaultValue: true,
+	}),
+	declareConfig("chat.hide_bits_balance", "TOGGLE", {
+		label: "Hide Bits Balance",
+		hint: "Hide the bits balance in the chat.",
+		path: ["Chat", "Style"],
+		defaultValue: false,
 	}),
 ];
 </script>

--- a/src/site/twitch.tv/modules/chat/components/tray/ChatTray.ts
+++ b/src/site/twitch.tv/modules/chat/components/tray/ChatTray.ts
@@ -181,7 +181,7 @@ export function useTrayRef(options: Twitch.CustomTrayOptions, modifier: boolean 
 		$$typeof: REACT_ELEMENT_SYMBOL,
 		key: "body",
 		ref: (e: TrayRef) => (bodyRef.value = e),
-		type: "seventv-vue-component",
+		type: "seventv-tray-container-body",
 		props: {},
 	};
 

--- a/src/site/twitch.tv/modules/chat/components/tray/Tray.vue
+++ b/src/site/twitch.tv/modules/chat/components/tray/Tray.vue
@@ -19,6 +19,7 @@ const props = withDefaults(
 		messageHandler?: (v: string) => void;
 		placeholder?: string;
 		modifier?: boolean;
+		floating?: boolean;
 	}>(),
 	{
 		modifier: false,

--- a/src/site/twitch.tv/modules/custom-commands/Commands/Dashboard.vue
+++ b/src/site/twitch.tv/modules/custom-commands/Commands/Dashboard.vue
@@ -16,6 +16,8 @@
 import { nextTick, onMounted, onUnmounted, ref } from "vue";
 import { refAutoReset } from "@vueuse/core";
 import { SEVENTV_EMOTE_ID, SEVENTV_EMOTE_LINK } from "@/common/Constant";
+import { SevenTVRoles } from "@/common/Roles";
+import { useActor } from "@/composable/useActor";
 import { useSetMutation } from "@/composable/useSetMutation";
 import EnableTray from "./components/EnableTray.vue";
 import { useSettingsMenu } from "@/app/settings/Settings";
@@ -203,11 +205,29 @@ const commandAlias: Twitch.ChatCommand = {
 	group: "7TV",
 };
 
+const actor = useActor();
+const perms = [SevenTVRoles.ADMIN, SevenTVRoles.MODERATOR] as string[];
+
+const commandEditAnySet: Twitch.ChatCommand = {
+	name: "letmemamageemoteset",
+	description: "<Mod> Lets you edit any 7TV emote set",
+	helpText: "",
+	permissionLevel: 0,
+	handler: () => {
+		actor.editAnySet = true;
+	},
+	group: "7TV",
+	get hidden() {
+		return actor.editAnySet || mut.canEditSet || !actor.user?.roles?.some((v) => perms.includes(v));
+	},
+};
+
 onMounted(() => {
 	props.add(commandSearch);
 	props.add(commandEnable);
 	props.add(commandDisable);
 	props.add(commandAlias);
+	props.add(commandEditAnySet);
 });
 
 onUnmounted(() => {
@@ -215,6 +235,7 @@ onUnmounted(() => {
 	props.remove(commandEnable);
 	props.remove(commandDisable);
 	props.remove(commandAlias);
+	props.remove(commandEditAnySet);
 });
 </script>
 

--- a/src/site/twitch.tv/modules/custom-commands/Commands/Dashboard.vue
+++ b/src/site/twitch.tv/modules/custom-commands/Commands/Dashboard.vue
@@ -4,6 +4,7 @@
 		placeholder="Search again..."
 		:input-value-override="search"
 		disable-commands
+		floating
 		:message-handler="(m) => (search = m)"
 	>
 		<EnableTray :search="search" :mut="mut" name="body" @close="showTray = false" />

--- a/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
+++ b/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
@@ -246,13 +246,65 @@ export const config = [
 }
 
 .seventv-hide-recommended-channels {
-	#side-nav > *:nth-child(1) > *:nth-child(1) > *:nth-child(4) {
+	div[class$="side-nav--collapsed"]
+		> *:nth-child(1)
+		> *:nth-child(1)
+		> *:nth-child(1)
+		> *:nth-child(3)
+		> *:nth-child(1)
+		> *:nth-child(1)
+		> *:nth-child(2)
+		> *:nth-child(1)
+		> *:nth-child(1)
+		> *:nth-child(1)
+		> *:nth-child(3) {
+		display: none !important;
+	}
+
+	div[class$="side-nav--expanded"]
+		> *:nth-child(1)
+		> *:nth-child(1)
+		> *:nth-child(1)
+		> *:nth-child(3)
+		> *:nth-child(1)
+		> *:nth-child(1)
+		> *:nth-child(2)
+		> *:nth-child(1)
+		> *:nth-child(1)
+		> *:nth-child(1)
+		> *:nth-child(4) {
 		display: none !important;
 	}
 }
 
 .seventv-hide-viewers-also-watch {
-	#side-nav > *:nth-child(1) > *:nth-child(1) > *:nth-child(5) {
+	div[class$="side-nav--collapsed"]
+		> *:nth-child(1)
+		> *:nth-child(1)
+		> *:nth-child(1)
+		> *:nth-child(3)
+		> *:nth-child(1)
+		> *:nth-child(1)
+		> *:nth-child(2)
+		> *:nth-child(1)
+		> *:nth-child(1)
+		> *:nth-child(1)
+		> *:nth-child(4) {
+		display: none !important;
+	}
+
+	div[class$="side-nav--expanded"]
+		> *:nth-child(1)
+		> *:nth-child(1)
+		> *:nth-child(1)
+		> *:nth-child(3)
+		> *:nth-child(1)
+		> *:nth-child(1)
+		> *:nth-child(2)
+		> *:nth-child(1)
+		> *:nth-child(1)
+		> *:nth-child(1)
+		> *:nth-child(5) {
 		display: none !important;
 	}
 }

--- a/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
+++ b/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
@@ -155,6 +155,17 @@ export const config = [
 		hint: "If checked, on-screen celebrations will be hidden",
 		defaultValue: false,
 	}),
+	declareConfig("layout.hide_whispers", "DROPDOWN", {
+		path: ["Site Layout", "Twitch Features"],
+		label: "Hide Whispers",
+		hint: "Choose when to hide whispers, fullscreen means when chat is hidden",
+		options: [
+			["Never", 0],
+			["Fullscreen", 1],
+			["Allways", 2],
+		],
+		defaultValue: 0,
+	}),
 ];
 </script>
 
@@ -290,6 +301,18 @@ export const config = [
 
 .seventv-hide-onscreen-celebrations {
 	div.celebration__overlay {
+		display: none !important;
+	}
+}
+
+.seventv-hide-whispers-fullscreen {
+	div.whispers-open-threads:not(.whispers--right-column-expanded-beside) {
+		display: none !important;
+	}
+}
+
+.seventv-hide-whispers-all {
+	div.whispers-open-threads {
 		display: none !important;
 	}
 }

--- a/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
+++ b/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
@@ -166,6 +166,12 @@ export const config = [
 		],
 		defaultValue: 0,
 	}),
+	declareConfig("layout.hide_stories", "TOGGLE", {
+		path: ["Site Layout", "Sidebar"],
+		label: "Hide Stories",
+		hint: "If checked, Stories will be hidden from the side bar",
+		defaultValue: false,
+	}),
 ];
 </script>
 
@@ -240,13 +246,13 @@ export const config = [
 }
 
 .seventv-hide-recommended-channels {
-	#side-nav > *:nth-child(1) > *:nth-child(1) > *:nth-child(3) {
+	#side-nav > *:nth-child(1) > *:nth-child(1) > *:nth-child(4) {
 		display: none !important;
 	}
 }
 
 .seventv-hide-viewers-also-watch {
-	#side-nav > *:nth-child(1) > *:nth-child(1) > *:nth-child(4) {
+	#side-nav > *:nth-child(1) > *:nth-child(1) > *:nth-child(5) {
 		display: none !important;
 	}
 }
@@ -313,6 +319,15 @@ export const config = [
 
 .seventv-hide-whispers-all {
 	div.whispers-open-threads {
+		display: none !important;
+	}
+}
+
+.seventv-hide-stories {
+	div[class$="storiesLeftNavSection--csO9S"] {
+		display: none !important;
+	}
+	button:has(div[class$="storiesLeftNavSectionCollapsedButton--txKvw"]) {
 		display: none !important;
 	}
 }

--- a/src/site/twitch.tv/modules/hidden-elements/hiddenElements.ts
+++ b/src/site/twitch.tv/modules/hidden-elements/hiddenElements.ts
@@ -1,4 +1,4 @@
-import { Ref } from "vue";
+import { Ref, computed } from "vue";
 import { useConfig } from "@/composable/useSettings";
 
 const hideLeaderboard = useConfig<boolean>("layout.hide_channel_leaderboard");
@@ -22,7 +22,7 @@ const hideChatInputBox = useConfig<boolean>("layout.hide_chat_input_box");
 const hidePlayerExtensions = useConfig<boolean>("player.hide_player_extensions");
 const hideChannelPointBalanceButton = useConfig<boolean>("layout.hide_channel_point_balance_button");
 const hideOnscreenCelebrations = useConfig<boolean>("player.hide_onscreen_celebrations");
-
+const hideWhispers = useConfig<number>("layout.hide_whispers");
 export const hiddenElementSettings: Array<{ class: string; isHidden: Ref<boolean> }> = [
 	{ class: "seventv-hide-leaderboard", isHidden: hideLeaderboard },
 	{ class: "seventv-hide-buttons-below-chatbox", isHidden: hideButtonsBelowChatbox },
@@ -45,4 +45,6 @@ export const hiddenElementSettings: Array<{ class: string; isHidden: Ref<boolean
 	{ class: "seventv-hide-player-ext", isHidden: hidePlayerExtensions },
 	{ class: "seventv-hide-channel-point-balance-button", isHidden: hideChannelPointBalanceButton },
 	{ class: "seventv-hide-onscreen-celebrations", isHidden: hideOnscreenCelebrations },
+	{ class: "seventv-hide-whispers-fullscreen", isHidden: computed(() => hideWhispers.value === 1) },
+	{ class: "seventv-hide-whispers-all", isHidden: computed(() => hideWhispers.value === 2) },
 ];

--- a/src/site/twitch.tv/modules/hidden-elements/hiddenElements.ts
+++ b/src/site/twitch.tv/modules/hidden-elements/hiddenElements.ts
@@ -23,6 +23,7 @@ const hidePlayerExtensions = useConfig<boolean>("player.hide_player_extensions")
 const hideChannelPointBalanceButton = useConfig<boolean>("layout.hide_channel_point_balance_button");
 const hideOnscreenCelebrations = useConfig<boolean>("player.hide_onscreen_celebrations");
 const hideWhispers = useConfig<number>("layout.hide_whispers");
+const hideStories = useConfig<boolean>("layout.hide_stories");
 export const hiddenElementSettings: Array<{ class: string; isHidden: Ref<boolean> }> = [
 	{ class: "seventv-hide-leaderboard", isHidden: hideLeaderboard },
 	{ class: "seventv-hide-buttons-below-chatbox", isHidden: hideButtonsBelowChatbox },
@@ -47,4 +48,5 @@ export const hiddenElementSettings: Array<{ class: string; isHidden: Ref<boolean
 	{ class: "seventv-hide-onscreen-celebrations", isHidden: hideOnscreenCelebrations },
 	{ class: "seventv-hide-whispers-fullscreen", isHidden: computed(() => hideWhispers.value === 1) },
 	{ class: "seventv-hide-whispers-all", isHidden: computed(() => hideWhispers.value === 2) },
+	{ class: "seventv-hide-stories", isHidden: hideStories },
 ];

--- a/src/types/app.d.ts
+++ b/src/types/app.d.ts
@@ -480,6 +480,7 @@ declare namespace FFZ {
 			display_name: string;
 		} | null;
 		urls: LinkMap;
+		animated?: LinkMap;
 	}
 
 	interface BadgesResponse {

--- a/src/types/twitch.d.ts
+++ b/src/types/twitch.d.ts
@@ -437,6 +437,10 @@ declare module Twitch {
 		determineGroup: (command: ChatCommand) => string;
 	};
 
+	export type ChatCommunityPointsButtonComponent = ReactExtended.WritableComponent<{}> & {
+		shouldShowBitsBalance: () => boolean;
+	};
+
 	export type ChatChannelPointsClaimComponent = ReactExtended.WritableComponent<{
 		hidden: boolean;
 	}> & {

--- a/src/types/twitch.d.ts
+++ b/src/types/twitch.d.ts
@@ -480,6 +480,7 @@ declare module Twitch {
 		sendMessageHandler?: ChatTray.SendMessageHandler<H>;
 		messageHandler?: (v: string) => void;
 		placeholder?: string;
+		floating?: boolean;
 	}
 
 	export namespace ChatTray {


### PR DESCRIPTION
## Proposed changes

Twitch recently introduced Stories to their page. These now have a dedicated button in the sidebar for them.
Since many users are not interested in these stories at all an option to hide this button from the sidebar should be added.
This new button also broke the already existing settings to hide recommended channels and channels that viewers also watch.
The functionality of these 2 settings should be fixed.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The option to hide the new Stories from the sidebar was pretty straight forward, because Twitch luckily used unique classnames for them.
The fix of the other 2 options is a bit ugly though.
Since the current implementation uses nth child calls to get to the correct divs (that's also the reason why they broke in the first place) and the number of children changes depending on if the sidebar is collapsed or expanded, even more nth child calls were neccessary. This is just a temporary quick fix though. A cleaner solution for a complete refactoring of the sidebar handling already exists by chips here https://github.com/SevenTV/Extension/pull/767
