### PR TITLE
Fix: fixed mentions not being clickable when colored mentions are turned off

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -3,6 +3,7 @@
 -   Fixed some settings on kick
 -   Added more drop shadow settings
 -   Added link to creators 7TV profile to emote cards of 7TV emotes
+-   Fixed mentions not being clickable when colred mentions are turned off
 
 ### 3.1.2.1000
 

--- a/src/app/chat/MessageTokenMention.vue
+++ b/src/app/chat/MessageTokenMention.vue
@@ -11,7 +11,6 @@
 			"
 			:as-mention="asMention"
 			:hide-badges="true"
-			:colored-mention="shouldRenderColoredMentions"
 			:style="shouldRenderColoredMentions ? { color: token.content.user?.color } : null"
 		/>
 	</span>

--- a/src/app/chat/MessageTokenMention.vue
+++ b/src/app/chat/MessageTokenMention.vue
@@ -1,22 +1,19 @@
 <template>
 	<span class="mention-token">
-		<span v-if="shouldRenderColoredMentions" :style="{ color: token.content.user?.color }">
-			<UserTag
-				:user="
-					token.content.user ?? {
-						id: uuid(),
-						username: tag.toLowerCase(),
-						displayName: tag,
-						color: '',
-					}
-				"
-				:as-mention="asMention"
-				:hide-badges="true"
-			/>
-		</span>
-		<span v-else>
-			{{ token.content.displayText }}
-		</span>
+		<UserTag
+			:user="
+				token.content.user ?? {
+					id: uuid(),
+					username: tag.toLowerCase(),
+					displayName: tag,
+					color: '',
+				}
+			"
+			:as-mention="asMention"
+			:hide-badges="true"
+			:colored-mention="shouldRenderColoredMentions"
+			:style="shouldRenderColoredMentions ? { color: token.content.user?.color } : null"
+		/>
 	</span>
 </template>
 
@@ -31,7 +28,7 @@ const props = defineProps<{
 	msg?: ChatMessage;
 }>();
 
-const shouldRenderColoredMentions = useConfig("chat.colored_mentions");
+const shouldRenderColoredMentions = useConfig<boolean>("chat.colored_mentions");
 
 const asMention = props.token.content.displayText.charAt(0) === "@";
 const tag = asMention ? props.token.content.displayText.slice(1) : props.token.content.displayText;

--- a/src/app/chat/UserTag.vue
+++ b/src/app/chat/UserTag.vue
@@ -35,11 +35,11 @@
 
 		<!-- Message Author -->
 		<span
-			v-tooltip="paint && paint.data ? `Paint: ${paint.data.name}` : ''"
+			v-tooltip="paint && paint.data && !(asMention && !coloredMention) ? `Paint: ${paint.data.name}` : ''"
 			class="seventv-chat-user-username"
 			@click="handleClick($event)"
 		>
-			<span v-cosmetic-paint="shouldRenderPaint && paint ? paint.id : null">
+			<span v-cosmetic-paint="shouldRenderPaint && !(asMention && !coloredMention) && paint ? paint.id : null">
 				<span v-if="asMention">@</span>
 				<span>{{ user.displayName }}</span>
 				<span v-if="user.intl"> ({{ user.username }})</span>
@@ -83,6 +83,7 @@ const props = withDefaults(
 		hideBadges?: boolean;
 		clickable?: boolean;
 		badges?: Record<string, string>;
+		coloredMention?: boolean;
 	}>(),
 	{
 		clickable: true,

--- a/src/app/chat/UserTag.vue
+++ b/src/app/chat/UserTag.vue
@@ -35,11 +35,17 @@
 
 		<!-- Message Author -->
 		<span
-			v-tooltip="paint && paint.data && !(asMention && !coloredMention) ? `Paint: ${paint.data.name}` : ''"
+			v-tooltip="
+				paint && paint.data && !(asMention && !shouldRenderColoredMentions) ? `Paint: ${paint.data.name}` : ''
+			"
 			class="seventv-chat-user-username"
 			@click="handleClick($event)"
 		>
-			<span v-cosmetic-paint="shouldRenderPaint && !(asMention && !coloredMention) && paint ? paint.id : null">
+			<span
+				v-cosmetic-paint="
+					shouldRenderPaint && !(asMention && !shouldRenderColoredMentions) && paint ? paint.id : null
+				"
+			>
 				<span v-if="asMention">@</span>
 				<span>{{ user.displayName }}</span>
 				<span v-if="user.intl"> ({{ user.username }})</span>
@@ -83,7 +89,6 @@ const props = withDefaults(
 		hideBadges?: boolean;
 		clickable?: boolean;
 		badges?: Record<string, string>;
-		coloredMention?: boolean;
 	}>(),
 	{
 		clickable: true,
@@ -102,6 +107,7 @@ const shouldRender7tvBadges = useConfig("vanity.7tv_Badges");
 const betterUserCardEnabled = useConfig("chat.user_card");
 const twitchBadges = ref<Twitch.ChatBadge[]>([]);
 const twitchBadgeSets = toRef(properties, "twitchBadgeSets");
+const shouldRenderColoredMentions = useConfig("chat.colored_mentions");
 
 const tagRef = ref<HTMLDivElement>();
 const showUserCard = ref(false);


### PR DESCRIPTION
## Proposed changes

When colored mentions are turned off (new default value) mentions are not clickable anymore to open the usercard, because they were rendered as just normal text. This was fixed in this PR

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

If this is a relatively large or complex change, you may want to start the discussion by explaining why you chose the solution you did, what alternatives you considered, etc.
