### PR TITLE
Fix a bug where the "Bypass Duplicate Message Check" setting is ignored (proof of concept)

### DIFF
--- a/src/site/twitch.tv/modules/chat-input/ChatSpam.vue
+++ b/src/site/twitch.tv/modules/chat-input/ChatSpam.vue
@@ -22,6 +22,7 @@ import { UNICODE_TAG_0, UNICODE_TAG_0_REGEX } from "@/common/Constant";
 import type { HookedInstance } from "@/common/ReactHooks";
 import { useFloatScreen } from "@/composable/useFloatContext";
 import { getModuleRef } from "@/composable/useModule";
+import { useConfig } from "@/composable/useSettings";
 import UiConfirmPrompt from "@/ui/UiConfirmPrompt.vue";
 import UiSuperHint from "@/ui/UiSuperHint.vue";
 import { offset } from "@floating-ui/core";
@@ -44,9 +45,10 @@ const suggestContainer = useFloatScreen(rootEl, {
 });
 
 const alt = refAutoReset(false, 3e4);
+const shouldBypassDuplicateCheck = useConfig("chat_input.spam.bypass_duplicate");
 let prevMessage = "";
 function handleDuplicateMessage(content: string): string {
-	if (typeof content === "string" && content === prevMessage) {
+	if (shouldBypassDuplicateCheck.value && typeof content === "string" && content === prevMessage) {
 		// Remove existing unicode tags
 		// avoids conflict with other extensions
 		content = content.replace(UNICODE_TAG_0_REGEX, "");


### PR DESCRIPTION
## Proposed changes

Describe the big picture of what you want to change here, to help the maintainers understand why we should accept this pull request. Be sure to link to the issue if it fixes a bug or resolves a feature request.

There is a bug where the setting _Chat > Typing > Bypass Duplicate Message Check_ is ignored when unchecked (see issue #845).  Since the bypass inserts an invisible Unicode character (a space and then U+E0000), this can cause 7tv users to be timed out by Twitch moderation bots (AecroBot specifically) that disallow certain classes of Unicode characters.

I was able to confirm in local testing that this fix causes 7tv to not insert the bypass when the setting is unchecked and to insert the bypass when the setting is checked.

I consider this PR to be a proof of concept because I'm not familiar enough with the conventions of Vue development and the 7tv code base.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged
