### PR TITLE
Typo in SettingsViewProfile.vue

### DIFF
--- a/src/app/settings/SettingsViewProfile.vue
+++ b/src/app/settings/SettingsViewProfile.vue
@@ -9,7 +9,7 @@
 		</template>
 		<template v-else-if="actor.user && actor.token">
 			You are authenticated with 7TV <br />
-			Try using the the custom 7TV commands if a channel where you have editor rights
+			Try using the custom 7TV commands in a channel where you have editor rights
 		</template>
 		<template v-else>
 			<button class="login-button" @click="login">Sign in</button>


### PR DESCRIPTION
## Proposed changes

This pull request fixes a minor typo in `SettingsViewProfile.vue`. The phrase:  
> "Try using the the custom 7TV commands if a channel where you have editor rights"  
has been corrected to:  
> "Try using the custom 7TV commands in a channel where you have editor rights."

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged
