### PR TITLE
FIX - replaced Unicode tag for duplicate message check

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,3 +1,7 @@
+### 3.1.10.1000
+
+- Replaced Unicode tag that gets appended for duplicate message check to not have it dropped by Twitch anymore
+
 ### 3.1.9.1000
 
 - Remove hosted-site functionality

--- a/src/common/Constant.ts
+++ b/src/common/Constant.ts
@@ -17,7 +17,7 @@ export const SITE_ASSETS_URL: InjectionKey<string> = Symbol("seventv-site-assets
 export const SITE_EXT_OPTIONS_URL: InjectionKey<string> = Symbol("seventv-site-ext-options-url");
 export const SITE_ACTIVE_WINDOW: InjectionKey<Window> = Symbol("seventv-site-active-window");
 
-export const UNICODE_TAG_0 = "\u{E0000}";
+export const UNICODE_TAG_0 = "\u{34f}";
 export const UNICODE_TAG_0_REGEX = new RegExp(UNICODE_TAG_0, "g");
 
 export const TWITCH_PROFILE_IMAGE_REGEX = /(\d+x\d+)(?=\.\w{3,4}$)/;


### PR DESCRIPTION
## Proposed changes

The unicode tag that was appended to messages to prevent the duplicate message check was getting dropped by Twitch after an update. By changing the tag from `\u{e0000}` to `\u{34f} ` the check should work again (and also in the future since emojis rely on the tag)

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged
