### PR TITLE
Proposed fix to make apollo stop recommending the Apollo Dev Tools in the console.

### DIFF
--- a/src/apollo/apollo.ts
+++ b/src/apollo/apollo.ts
@@ -28,4 +28,5 @@ const cache = new InMemoryCache();
 export const apolloClient = new ApolloClient({
 	link,
 	cache,
+	connectToDevTools: false, 
 });


### PR DESCRIPTION
Adding this config key to the apolloClient object should make it stop logging the "Try the apollo dev tools" console log ad.
It should also only appear if the project is in development mode, but it might be bugged as i was getting it too with the release branch build of 7TV.

## Proposed changes

This is a small PR and only aims to stop Apollo from advertising their dev tools to the end user of the extension, by preventing apollo from trying to connect to the Apollo Dev Tools, as mentioned above, it shouldn't do this in production, but for some reason it has been, so this is the only fix I could think of.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged
