### PR TITLE
feat(twitch): force HD video

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,5 +1,6 @@
 ### 3.1.20.1000
 
+-   Added option to force HD video on Twitch
 -   Fixed some lint issues
 -   Bump version to 3.1.20
 

--- a/src/site/twitch.tv/modules/player/PlayerForceHD.vue
+++ b/src/site/twitch.tv/modules/player/PlayerForceHD.vue
@@ -1,0 +1,80 @@
+<template />
+
+<script setup lang="ts">
+import { onMounted, toRaw } from "vue";
+import { log } from "@/common/Logger";
+import { HookedInstance } from "@/common/ReactHooks";
+
+const props = defineProps<{
+	inst: HookedInstance<Twitch.VideoPlayerComponent>;
+}>();
+
+function getQualityKey(quality: string | Twitch.VideoQuality | undefined): string {
+	if (!quality) return "";
+	if (typeof quality === "string") return quality;
+	return quality.group || quality.name || "";
+}
+
+function matchesQuality(current: string | Twitch.VideoQuality | undefined, quality: Twitch.VideoQuality): boolean {
+	const currentKey = getQualityKey(current);
+	return currentKey === getQualityKey(quality) || currentKey === quality.name;
+}
+
+function compareQualities(a: Twitch.VideoQuality, b: Twitch.VideoQuality): number {
+	const aIsSource = a.variantSource === "source";
+	const bIsSource = b.variantSource === "source";
+
+	if (aIsSource !== bIsSource) {
+		return aIsSource ? -1 : 1;
+	}
+	if (a.height !== b.height) {
+		return b.height - a.height;
+	}
+	if (a.framerate !== b.framerate) {
+		return b.framerate - a.framerate;
+	}
+
+	return b.bitrate - a.bitrate;
+}
+
+function applyBestQuality(player: Twitch.MediaPlayerInstance) {
+	try {
+		const rawPlayer = toRaw(player);
+		const qualities = rawPlayer.getQualities().map(toRaw);
+		const [best] = qualities.filter((q) => q.name !== "auto").sort(compareQualities);
+		if (!best) {
+			return;
+		}
+
+		const current = rawPlayer.getQuality();
+		if (matchesQuality(current, best)) {
+			return;
+		}
+
+		if (rawPlayer.isAutoQualityMode()) {
+			rawPlayer.setAutoQualityMode(false);
+		}
+
+		rawPlayer.setQuality(best);
+	} catch (err) {
+		log.error("<Player>", "<ForceHD> applyBestQuality failed", String(err));
+	}
+}
+
+function sync() {
+	// Defer this update so browser can prioritize more important tasks
+	requestIdleCallback(
+		() => {
+			applyBestQuality(props.inst.component.props.mediaPlayerInstance);
+		},
+		// 1 second max delay for some guarantees
+		{ timeout: 1000 },
+	);
+}
+
+onMounted(() => {
+	sync();
+});
+
+defineExpose({ sync });
+</script>

--- a/src/site/twitch.tv/modules/player/PlayerModule.vue
+++ b/src/site/twitch.tv/modules/player/PlayerModule.vue
@@ -1,6 +1,7 @@
 <template>
 	<template v-for="inst of player.instances" :key="inst.identifier">
 		<PlayerController :inst="inst" :media-player="mediaPlayer" />
+		<PlayerForceHD v-if="shouldForceHDVideo" ref="forceHD" :inst="inst" />
 	</template>
 
 	<template v-if="playerAdvancedOptionsComponent.instances.length > 0">
@@ -19,6 +20,7 @@ import { declareModule } from "@/composable/useModule";
 import { declareConfig, useConfig } from "@/composable/useSettings";
 import PlayerController from "./PlayerController.vue";
 import { ref } from "vue";
+import PlayerForceHD from "./PlayerForceHD.vue";
 import PlayerStreamInfo from "./PlayerStreamInfo.vue";
 
 declareModule<"TWITCH">("player", {
@@ -29,7 +31,9 @@ declareModule<"TWITCH">("player", {
 const mediaPlayer = ref<Twitch.MediaPlayerInstance>();
 
 const shouldShowVideoStats = useConfig<boolean>("player.video_stats");
+const shouldForceHDVideo = useConfig<boolean>("player.force_hd_video");
 const info = ref<typeof PlayerStreamInfo | null>(null);
+const forceHD = ref<(typeof PlayerForceHD)[] | null>(null);
 
 const player = useComponentHook<Twitch.VideoPlayerComponent>(
 	{
@@ -41,6 +45,7 @@ const player = useComponentHook<Twitch.VideoPlayerComponent>(
 			render(inst, cur) {
 				mediaPlayer.value = inst.component.props.mediaPlayerInstance;
 				info.value?.remount?.();
+				forceHD.value?.forEach((f) => f.sync?.());
 
 				return cur;
 			},
@@ -78,6 +83,12 @@ export const config = [
 			["Mute/Unmute", 2],
 		],
 		defaultValue: 0,
+	}),
+	declareConfig("player.force_hd_video", "TOGGLE", {
+		path: ["Player", ""],
+		label: "Force HD Video",
+		hint: "Automatically select the highest available video quality",
+		defaultValue: false,
 	}),
 ];
 </script>

--- a/src/types/twitch.d.ts
+++ b/src/types/twitch.d.ts
@@ -918,6 +918,11 @@ declare module Twitch {
 		setMuted: (e) => void;
 		setVolume: (e) => void;
 		setPlaybackRate: (e) => void;
+		setQuality: (quality: string | VideoQuality) => void;
+		getQuality: () => string | VideoQuality;
+		getQualities: () => VideoQuality[];
+		setAutoQualityMode: (enabled: boolean) => void;
+		isAutoQualityMode: () => boolean;
 	}
 
 	export type VideoPlayerContentRestriction = ReactExtended.WritableComponent<{
@@ -986,5 +991,6 @@ declare module Twitch {
 		isDefault: boolean;
 		name: string;
 		width: number;
+		variantSource: string;
 	}
 }


### PR DESCRIPTION
## Proposed changes

Adds a Twitch player setting, `Force HD Video`, that automatically selects the highest available quality for any active stream.

Fixes #628 by using Twitch's player quality API to prefer the best available variant and to prefer `Source` when multiple entries share the same displayed quality.

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [ ] ~~Any dependent changes have been merged~~