### PR TITLE
Fix attempt for issue #1228

### DIFF
--- a/src/app/settings/SettingsConfigHighlights.vue
+++ b/src/app/settings/SettingsConfigHighlights.vue
@@ -423,6 +423,7 @@ function onUseDefaultSound(h: HighlightDef): void {
 	delete h.soundDef;
 	h.soundPath = "#ping";
 
+	highlights.updateSoundData(h);
 	highlights.save();
 }
 

--- a/src/composable/chat/useChatHighlights.ts
+++ b/src/composable/chat/useChatHighlights.ts
@@ -260,8 +260,8 @@ export function useChatHighlights(ctx: ChannelContext) {
 		const filteredHighlights = Object.fromEntries(
 			Object.entries(data.highlights).filter(
 				([, highlight]) =>
-					highlight.persist &&
-					highlight.phrase === true || (!highlight.phrase && !highlight.username && !highlight.badge),
+					highlight.persist === true &&
+					(highlight.phrase === true || (!highlight.phrase && !highlight.username && !highlight.badge)),
 			),
 		);
 
@@ -271,7 +271,7 @@ export function useChatHighlights(ctx: ChannelContext) {
 	function getAllUsernameHighlights(): Record<string, HighlightDef> {
 		if (!data) return {};
 		const filteredHighlights = Object.fromEntries(
-			Object.entries(data.highlights).filter(([, highlight]) => highlight.persist && highlight.username === true),
+			Object.entries(data.highlights).filter(([, highlight]) => highlight.persist === true && highlight.username === true),
 		);
 
 		return toReactive(filteredHighlights);
@@ -280,7 +280,7 @@ export function useChatHighlights(ctx: ChannelContext) {
 	function getAllBadgeHighlights(): Record<string, HighlightDef> {
 		if (!data) return {};
 		const filteredHighlights = Object.fromEntries(
-			Object.entries(data.highlights).filter(([, highlight]) => highlight.persist && highlight.badge === true),
+			Object.entries(data.highlights).filter(([, highlight]) => highlight.persist === true && highlight.badge === true),
 		);
 
 		return toReactive(filteredHighlights);

--- a/src/composable/chat/useChatHighlights.ts
+++ b/src/composable/chat/useChatHighlights.ts
@@ -260,6 +260,7 @@ export function useChatHighlights(ctx: ChannelContext) {
 		const filteredHighlights = Object.fromEntries(
 			Object.entries(data.highlights).filter(
 				([, highlight]) =>
+					highlight.persist &&
 					highlight.phrase === true || (!highlight.phrase && !highlight.username && !highlight.badge),
 			),
 		);
@@ -270,7 +271,7 @@ export function useChatHighlights(ctx: ChannelContext) {
 	function getAllUsernameHighlights(): Record<string, HighlightDef> {
 		if (!data) return {};
 		const filteredHighlights = Object.fromEntries(
-			Object.entries(data.highlights).filter(([, highlight]) => highlight.username === true),
+			Object.entries(data.highlights).filter(([, highlight]) => highlight.persist && highlight.username === true),
 		);
 
 		return toReactive(filteredHighlights);
@@ -279,7 +280,7 @@ export function useChatHighlights(ctx: ChannelContext) {
 	function getAllBadgeHighlights(): Record<string, HighlightDef> {
 		if (!data) return {};
 		const filteredHighlights = Object.fromEntries(
-			Object.entries(data.highlights).filter(([, highlight]) => highlight.badge === true),
+			Object.entries(data.highlights).filter(([, highlight]) => highlight.persist && highlight.badge === true),
 		);
 
 		return toReactive(filteredHighlights);

--- a/src/site/App.vue
+++ b/src/site/App.vue
@@ -86,11 +86,6 @@ bc.addEventListener("message", (ev) => {
 		(n) => !settings.nodes[n.key] || n.timestamp > (settings.nodes[n.key].timestamp ?? 0),
 	);
 
-	const newNodes = nodes.filter((n) => {
-		const localNode = settings.nodes[n.key];
-		return !localNode || n.timestamp > (localNode.timestamp ?? 0);
-	});
-
 	for (const node of newNodes) {
 		const n = useConfig(node.key);
 		if (!n || !n.value) continue;

--- a/src/site/App.vue
+++ b/src/site/App.vue
@@ -86,6 +86,11 @@ bc.addEventListener("message", (ev) => {
 		(n) => !settings.nodes[n.key] || n.timestamp > (settings.nodes[n.key].timestamp ?? 0),
 	);
 
+	const newNodes = nodes.filter((n) => {
+		const localNode = settings.nodes[n.key];
+		return !localNode || n.timestamp > (localNode.timestamp ?? 0);
+	});
+
 	for (const node of newNodes) {
 		const n = useConfig(node.key);
 		if (!n || !n.value) continue;

--- a/src/site/twitch.tv/modules/chat/ChatModule.vue
+++ b/src/site/twitch.tv/modules/chat/ChatModule.vue
@@ -365,7 +365,7 @@ export const config = [
 		label: "Play Sound on Mention",
 		hint: "Play a sound when you are mentioned in chat",
 		disabledIf: () => !useConfig("highlights.basic.mention").value,
-		defaultValue: false,
+		defaultValue: true,
 	}),
 	declareConfig<boolean>("highlights.basic.mention_title_flash", "TOGGLE", {
 		path: ["Highlights", "Built-In"],


### PR DESCRIPTION
## Proposed changes

The user described a bug (issue #1228) that caused the mention/reply sound to not play and automatically reset in the settings. Having a look at the codes I figured out that the built-in mention/reply highlights are being edited through the custom-highlight UI even though they are intentionally non-persistent. Therefore I fixed two main things:

- built-in mentions/replies are no longer displayed as editable "Custom Highlights"
- clicking "Default Sound" directly resets the soundDef


## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [] I have added necessary documentation (if appropriate)
- [X] Any dependent changes have been merged

## Further notes

Since these changes are only an attempt to fully fix the bug, some further code adjustments might need to be made. Feel free to suggest improvements.
