### PR TITLE
possible fix for restoring missing twitch mod action buttons

### DIFF
--- a/src/site/twitch.tv/modules/chat-input-controller/ChatInputControllerModule.vue
+++ b/src/site/twitch.tv/modules/chat-input-controller/ChatInputControllerModule.vue
@@ -146,7 +146,7 @@ div[data-test-selector="chat-input-buttons-container"] seventv-chat-input-button
 div[data-test-selector="chat-input-buttons-container"] > div:has(button[data-a-target="chat-settings"]) {
 	display: contents !important;
 
-	> :not(:has(button[data-a-target="chat-settings"])) {
+	> :not(:has(button)) {
 		display: none !important;
 	}
 }


### PR DESCRIPTION
## Proposed changes

Twitch restructured the DOM of the chat input button container, causing the mod buttons (auto mod shield and mod sword) to be caught by our overly broad CSS selector. To hopefully fix this issue #1241 I:

- narrowed :not(:has(...)) selector in ChatInputControllerModule.vue from excluding only the settings button to excluding any element that contains a button.
- mod action buttons should be visible again while the 7TV extension is active + empty layout wrappers continue to be hidden, keeping the input bar clean

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [X] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [X] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged
