### PR TITLE
fix: add hide chat button setting + fix mod buttons

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,3 +1,8 @@
+### 3.1.23.1000
+
+-   Fixed an issue that caused the Mod View + Shield Mode buttons to not show
+-   Fixed an issue where Chat Settings tooltip would display when hovering Mod Logs button
+
 ### 3.1.22.1000
 
 -   Fixed an issue that caused chat input to break after a Twitch update

--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,5 +1,6 @@
 ### 3.1.23.1000
 
+-   Added setting to hide Twitch "Chat" send button under the chat input box
 -   Fixed an issue that caused the Mod View + Shield Mode buttons to not show
 -   Fixed an issue where Chat Settings tooltip would display when hovering Mod Logs button
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### 3.1.23
 
+-   Added setting to hide Twitch "Chat" send button under the chat input box
 -   Fixed an issue that caused the Mod View + Shield Mode buttons to not show
 -   Fixed an issue where Chat Settings tooltip would display when hovering Mod Logs button
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### 3.1.23
+
+-   Fixed an issue that caused the Mod View + Shield Mode buttons to not show
+-   Fixed an issue where Chat Settings tooltip would display when hovering Mod Logs button
+
 ### 3.1.22
 
 -   Fixed an issue that caused chat input to break after a Twitch update

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"displayName": "7TV",
 	"description": "Improve your viewing experience on Twitch & Kick with new features, emotes, vanity and performance.",
 	"private": true,
-	"version": "3.1.22",
+	"version": "3.1.23",
 	"dev_version": "1.0",
 	"scripts": {
 		"start": "cross-env NODE_ENV=dev yarn build:dev && cross-env NODE_ENV=dev vite --mode dev",

--- a/src/site/twitch.tv/modules/chat-input-controller/ChatInputControllerModule.vue
+++ b/src/site/twitch.tv/modules/chat-input-controller/ChatInputControllerModule.vue
@@ -94,11 +94,12 @@ function remountButtons() {
 		row.querySelector<HTMLElement>("button[data-a-target='chat-settings']") ??
 		row.querySelector<HTMLElement>("button[data-a-target='chat-send-button']");
 	const wrapper = anchor?.parentElement;
-	const container = wrapper?.parentElement ?? row;
+	const buttonSlot = wrapper?.parentElement?.parentElement;
+	const container = buttonSlot?.parentElement ?? wrapper?.parentElement ?? row;
 
 	const buttons = [...tButtons.values()].sort((a, b) => b.offset - a.offset);
 
-	let reference: Element | null = wrapper ?? anchor;
+	let reference: Element | null = buttonSlot ?? wrapper ?? anchor;
 	for (let i = buttons.length - 1; i >= 0; i--) {
 		const btn = buttons[i];
 		const el = btn.parent.current;

--- a/src/site/twitch.tv/modules/chat-input-controller/ChatInputControllerModule.vue
+++ b/src/site/twitch.tv/modules/chat-input-controller/ChatInputControllerModule.vue
@@ -145,9 +145,5 @@ div[data-test-selector="chat-input-buttons-container"] seventv-chat-input-button
 
 div[data-test-selector="chat-input-buttons-container"] > div:has(button[data-a-target="chat-settings"]) {
 	display: contents !important;
-
-	> :not(:has(button[data-a-target="chat-settings"])) {
-		display: none !important;
-	}
 }
 </style>

--- a/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
+++ b/src/site/twitch.tv/modules/hidden-elements/HiddenElementsModule.vue
@@ -38,6 +38,12 @@ export const config = [
 		hint: "If checked, the 'Send a message' chatbox will be hidden (WARNING! the 7tv icon will disappear but can be accessed again at the top right of Twitch)",
 		defaultValue: false,
 	}),
+	declareConfig("layout.hide_chat_input_send_button", "TOGGLE", {
+		path: ["Site Layout", "Chat"],
+		label: "Hide Chat Button",
+		hint: "If checked, the Chat send button in the chat input area will be hidden",
+		defaultValue: false,
+	}),
 	declareConfig("layout.hide_buttons_below_chatbox", "TOGGLE", {
 		path: ["Site Layout", "Chat"],
 		label: "Hide Buttons Below Chatbox",
@@ -190,6 +196,12 @@ export const config = [
 <style lang="scss">
 .seventv-hide-buttons-below-chatbox {
 	div[data-test-selector="chat-input-buttons-container"] {
+		display: none !important;
+	}
+}
+
+.seventv-hide-chat-input-send-button {
+	button[data-a-target="chat-send-button"] {
 		display: none !important;
 	}
 }

--- a/src/site/twitch.tv/modules/hidden-elements/hiddenElements.ts
+++ b/src/site/twitch.tv/modules/hidden-elements/hiddenElements.ts
@@ -21,6 +21,7 @@ const hideCombosButton = useConfig<boolean>("layout.hide_combos_button");
 const hideLiveNotificationButton = useConfig<boolean>("layout.hide_live_notification_button");
 const hideSubscribeButton = useConfig<boolean>("layout.hide_subscribe_button");
 const hideChatInputBox = useConfig<boolean>("layout.hide_chat_input_box");
+const hideChatInputSendButton = useConfig<boolean>("layout.hide_chat_input_send_button");
 const hidePlayerExtensions = useConfig<boolean>("player.hide_player_extensions");
 const hideChannelPointBalanceButton = useConfig<boolean>("layout.hide_channel_point_balance_button");
 const hideOnscreenCelebrations = useConfig<boolean>("player.hide_onscreen_celebrations");
@@ -47,6 +48,7 @@ export const hiddenElementSettings: Array<{ class: string; isHidden: Ref<boolean
 	{ class: "seventv-hide-combos-buttons", isHidden: hideCombosButton },
 	{ class: "seventv-hide-subscribe-button", isHidden: hideSubscribeButton },
 	{ class: "seventv-hide-chat-input-box", isHidden: hideChatInputBox },
+	{ class: "seventv-hide-chat-input-send-button", isHidden: hideChatInputSendButton },
 	{ class: "seventv-hide-player-ext", isHidden: hidePlayerExtensions },
 	{ class: "seventv-hide-channel-point-balance-button", isHidden: hideChannelPointBalanceButton },
 	{ class: "seventv-hide-onscreen-celebrations", isHidden: hideOnscreenCelebrations },


### PR DESCRIPTION
## Proposed changes

- Fixes the issue where Mod View + Shield Mode buttons are being hidden
- Fixes the issue where the Chat Settings tooltip would show when you hover the Mod Logs button
- Added a setting to hide the Twitch "Chat" send button under the chat input box for when it's making the buttons container take up 2 lines

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged
