### PR TITLE
fix(kick): emote menu anchor

### DIFF
--- a/CHANGELOG-nightly.md
+++ b/CHANGELOG-nightly.md
@@ -1,5 +1,6 @@
 ## 3.1.25.1000
 
+-   Fixed Kick Emote Menu position
 -   Updated 7TV API logic
 
 ### 3.1.24.1000

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 3.1.25
 
+-   Fixed Kick Emote Menu position
 -   Updated 7TV API logic
 
 ### 3.1.24

--- a/src/site/kick.com/modules/emote-menu/EmoteMenu.vue
+++ b/src/site/kick.com/modules/emote-menu/EmoteMenu.vue
@@ -29,7 +29,7 @@ const props = defineProps<{
 
 const emoteMenu = useEmoteMenuContext();
 
-const emoteMenuAnchor = ref<HTMLDivElement | null>(null);
+const emoteMenuAnchor = ref<HTMLElement | null>(null);
 
 const emoteMenuButtonContainer = document.createElement("seventv-container");
 
@@ -42,9 +42,8 @@ function close(ev: MouseEvent): void {
 
 watch(
 	() => props.container,
-	async (container) => {
-		emoteMenuAnchor.value =
-			document.querySelector<HTMLDivElement>("#channel-chatroom > div > div:has(#chat-input-wrapper)") ?? null;
+	(container) => {
+		emoteMenuAnchor.value = container;
 
 		if (!container && emoteMenu.open) {
 			emoteMenu.open = false;


### PR DESCRIPTION
## Proposed changes

Fixes the emote menu on Kick opening in the incorrect place because of its anchor

## Types of changes

What types of changes does your code introduce to 7TV?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://github.com/SevenTV/SevenTV/blob/main/CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)
- [x] Any dependent changes have been merged
